### PR TITLE
feat: add "show source code" toggle for demos

### DIFF
--- a/example/lib/code_block.dart
+++ b/example/lib/code_block.dart
@@ -6,15 +6,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
-
 import 'package:syntax_highlight/syntax_highlight.dart';
 
 class CodeBlock extends StatefulWidget {
   final String code;
   final String language;
+  final bool expanded;
 
-  const CodeBlock({Key? key, required this.code, this.language = "dart"})
-      : super(key: key);
+  const CodeBlock({
+    Key? key,
+    required this.code,
+    this.language = "dart",
+    this.expanded = false,
+  }) : super(key: key);
 
   @override
   State<CodeBlock> createState() => _CodeBlockState();
@@ -30,6 +34,7 @@ class _CodeBlockState extends State<CodeBlock> {
   @override
   void initState() {
     lines = widget.code.trim().split("\n").length;
+    expanded = widget.expanded;
     loadHighlighter();
     super.initState();
   }

--- a/example/lib/components/component_well.dart
+++ b/example/lib/components/component_well.dart
@@ -1,4 +1,3 @@
-import 'package:dart_style/dart_style.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
@@ -72,15 +71,21 @@ class _ComponentWellState extends State<ComponentWell> {
         ));
   }
 
+  static final sourceCodeCache = <String, String>{};
+
   /// Builds the child with a button to toggle between the demo and the source code.
   Widget _buildChildWithSourceCode(BuildContext context) {
     final _sourcePath = widget.showSourceCodeOptions?.path ??
         "lib${GoRouter.of(context).state?.pageKey.value}.dart";
     return FutureBuilder<String>(
-      future: rootBundle.loadString(_sourcePath),
+      future: sourceCodeCache.containsKey(_sourcePath)
+          ? Future.value(sourceCodeCache[_sourcePath])
+          : rootBundle.loadString(_sourcePath),
       builder: (context, snapshot) {
+        String? demoSource = "";
         if (snapshot.connectionState == ConnectionState.done) {
           if (snapshot.hasData) {
+            sourceCodeCache[_sourcePath] = snapshot.data!;
             RegExp exp = RegExp(
                 r'/\*\s*begin demo:\s*' +
                     widget.showSourceCodeOptions!.tag +
@@ -88,47 +93,37 @@ class _ComponentWellState extends State<ComponentWell> {
                     widget.showSourceCodeOptions!.tag +
                     r'\s*\*/',
                 dotAll: true);
-            var demoSource = exp
-                .firstMatch(snapshot.data!)
-                ?.group(1)
-                ?.trim()
-                // make it a valid dart statement by putting a semicolon at the end:
-                .replaceAll(RegExp(r',$'), ';');
-            if (demoSource != null) {
-              return Column(
-                children: [
-                  Align(
-                    alignment: Alignment.centerRight,
-                    child: LdButtonGhost(
-                      leading: Icon(isShowingSourceCode
-                          ? Icons.grid_view_outlined
-                          : Icons.code),
-                      child: Text(isShowingSourceCode
-                          ? "Show Demo"
-                          : "Show Source Code"),
-                      onPressed: () => setState(
-                        () => isShowingSourceCode = !isShowingSourceCode,
-                      ),
-                    ),
-                  ),
-                  Visibility(
-                      child: widget.child, visible: !isShowingSourceCode),
-                  Visibility(
-                    child: CodeBlock(
-                      expanded: true,
-                      code: DartFormatter(
-                        languageVersion: DartFormatter.latestLanguageVersion,
-                        experimentFlags: [],
-                      ).formatStatement(demoSource),
-                    ),
-                    visible: isShowingSourceCode,
-                  ),
-                ],
-              );
-            }
+            demoSource = exp.firstMatch(snapshot.data!)?.group(1);
           }
         }
-        return widget.child;
+
+        return Column(
+          children: [
+            if (demoSource != null)
+              Align(
+                alignment: Alignment.centerRight,
+                child: LdButtonGhost(
+                  leading: Icon(isShowingSourceCode
+                      ? Icons.grid_view_outlined
+                      : Icons.code),
+                  child: Text(
+                      isShowingSourceCode ? "Show Demo" : "Show Source Code"),
+                  onPressed: () => setState(
+                    () => isShowingSourceCode = !isShowingSourceCode,
+                  ),
+                ),
+              ),
+            Visibility(child: widget.child, visible: !isShowingSourceCode),
+            if (demoSource?.isNotEmpty == true)
+              Visibility(
+                child: CodeBlock(
+                  code: demoSource!,
+                  expanded: true,
+                ),
+                visible: isShowingSourceCode,
+              ),
+          ],
+        );
       },
     );
   }

--- a/example/lib/components/component_well.dart
+++ b/example/lib/components/component_well.dart
@@ -15,14 +15,30 @@ class ShowSourceCodeOptions {
   /// ```
   /// where `tag` is the value of this property.
   /// The code between the `begin` and `end` comments will be displayed.
-  final String tag;
+  ///
+  /// If no tag is provided, the source code will be extracted in an elaborated
+  /// way counting the braces to ensure the entire child widget is captured.
+  ///
+  /// If multiple [ComponentWell] widgets are present in the same file, the
+  /// [componentWellIndex] property can be used to specify which one to extract.
+  ///
+  /// This method is less reliable and may not work in all cases.
+  final String? tag;
+
+  /// The index of the [ComponentWell] widget in the source code file. It will
+  /// only be used if the [tag] property is not provided.
+  final int? componentWellIndex;
 
   /// The path to the source code file, e.g. "lib/components/reactive_form.dart".
   /// If no path is provided, it will be tried to be inferred from the current
   /// route.
   final String? path;
 
-  ShowSourceCodeOptions({required this.tag, this.path});
+  /// Set to false to hide the source code button.
+  final bool showButton;
+
+  ShowSourceCodeOptions(
+      {this.tag, this.path, this.showButton = true, this.componentWellIndex});
 }
 
 class ComponentWell extends StatefulWidget {
@@ -45,11 +61,25 @@ class ComponentWell extends StatefulWidget {
 }
 
 class _ComponentWellState extends State<ComponentWell> {
+  /// Cache for the source code of the demo pages (to avoid having to reload
+  /// it again for each widget instance on a page).
+  static final _sourceCodeCache = <String, String>{};
+  static final Map<ValueKey<String>, int> _instanceCounters = {};
+  late int _instanceIndex; // Instance index for this widget
+  late ValueKey<String>? _pageKey; // Page key for this widget
   bool isShowingSourceCode = false;
+
+  /// The path to the source code file. If no path was provided via the
+  /// [ShowSourceCodeOptions], it will be inferred from the current route.
+  get _sourcePath =>
+      widget.showSourceCodeOptions?.path ?? "lib${_pageKey!.value}.dart";
 
   @override
   Widget build(BuildContext context) {
     final theme = LdTheme.of(context, listen: true);
+    // let's show the source code button by default
+    final showSourceCode = widget.showSourceCodeOptions?.showButton ?? true;
+
     return Container(
         width: double.infinity,
         decoration: BoxDecoration(
@@ -60,46 +90,80 @@ class _ComponentWellState extends State<ComponentWell> {
         ),
         padding: widget.padding ??
             EdgeInsets.symmetric(
-              vertical: widget.showSourceCodeOptions != null ? 16 : 32,
+              vertical: showSourceCode ? 16 : 32,
               horizontal: 16,
             ),
         child: Provider.value(
           value: LdSurfaceInfo(isSurface: widget.onSurface),
-          child: widget.showSourceCodeOptions != null
+          child: showSourceCode
               ? _buildChildWithSourceCode(context)
               : widget.child,
         ));
   }
 
-  static final sourceCodeCache = <String, String>{};
+  @override
+  void initState() {
+    // use the initState() lifecycle method to increment the instance counter,
+    // for each instance of the ComponentWell widget on the page. This should be
+    // safe as we assume that it gets called only once per instance on a page
+    // and in the correct order for the widget tree.
+    _pageKey = GoRouter.of(context).state?.pageKey;
+    if (_pageKey != null) {
+      _instanceIndex = _instanceCounters.putIfAbsent(_pageKey!, () => 0);
+      _instanceCounters[_pageKey!] = _instanceIndex + 1;
+    }
+    super.initState();
+  }
+
+  @override
+  dispose() {
+    // use the dispose() lifecycle method to reset the instance counter for the
+    // page when any of the ComponentWell widgets are disposed.
+    _sourceCodeCache.remove(_sourcePath);
+    _instanceCounters.remove(_pageKey!);
+    super.dispose();
+  }
 
   /// Builds the child with a button to toggle between the demo and the source code.
   Widget _buildChildWithSourceCode(BuildContext context) {
-    final _sourcePath = widget.showSourceCodeOptions?.path ??
-        "lib${GoRouter.of(context).state?.pageKey.value}.dart";
     return FutureBuilder<String>(
-      future: sourceCodeCache.containsKey(_sourcePath)
-          ? Future.value(sourceCodeCache[_sourcePath])
+      future: _sourceCodeCache.containsKey(_sourcePath)
+          ? Future.value(_sourceCodeCache[_sourcePath])
           : rootBundle.loadString(_sourcePath),
       builder: (context, snapshot) {
-        String? demoSource = "";
+        String? componentWellChildCode;
         if (snapshot.connectionState == ConnectionState.done) {
           if (snapshot.hasData) {
-            sourceCodeCache[_sourcePath] = snapshot.data!;
-            RegExp exp = RegExp(
-                r'/\*\s*begin demo:\s*' +
-                    widget.showSourceCodeOptions!.tag +
-                    r'\s*\*/(.*)\/\*\s*end demo:\s*' +
-                    widget.showSourceCodeOptions!.tag +
-                    r'\s*\*/',
-                dotAll: true);
-            demoSource = exp.firstMatch(snapshot.data!)?.group(1);
+            _sourceCodeCache[_sourcePath] = snapshot.data!;
+
+            if (widget.showSourceCodeOptions?.tag != null) {
+              // Extract the source code between the 'begin' and 'end' comments
+              final RegExp exp = RegExp(
+                  r'/\*\s*begin demo:\s*' +
+                      widget.showSourceCodeOptions!.tag! +
+                      r'\s*\*/(.*)\/\*\s*end demo:\s*' +
+                      widget.showSourceCodeOptions!.tag! +
+                      r'\s*\*/',
+                  dotAll: true);
+              componentWellChildCode = exp.firstMatch(snapshot.data!)?.group(1);
+            }
+
+            if (componentWellChildCode?.isEmpty ?? true) {
+              // If no tag was provided or the tag was not found, we try to
+              // extract the content of the 'child' property of the ComponentWell
+              // widget in a more elaborated way.
+              componentWellChildCode = extractComponentWellChildCode(
+                snapshot.data!,
+                index: widget.showSourceCodeOptions?.componentWellIndex ??
+                    _instanceIndex,
+              );
+            }
           }
         }
 
         return Column(
           children: [
-            if (demoSource != null)
+            if (componentWellChildCode?.isNotEmpty ?? false)
               Align(
                 alignment: Alignment.centerRight,
                 child: LdButtonGhost(
@@ -114,10 +178,10 @@ class _ComponentWellState extends State<ComponentWell> {
                 ),
               ),
             Visibility(child: widget.child, visible: !isShowingSourceCode),
-            if (demoSource?.isNotEmpty == true)
+            if (componentWellChildCode?.isNotEmpty ?? false)
               Visibility(
                 child: CodeBlock(
-                  code: demoSource!,
+                  code: componentWellChildCode!,
                   expanded: true,
                 ),
                 visible: isShowingSourceCode,
@@ -127,4 +191,46 @@ class _ComponentWellState extends State<ComponentWell> {
       },
     );
   }
+}
+
+/// Extracts the content of the 'child' property of a 'ComponentWell' widget
+/// from a Dart code string. If multiple 'ComponentWell' widgets are present in
+/// the same file, the [index] property can be used to specify which one to
+/// extract.
+String? extractComponentWellChildCode(String dartCode, {int index = 0}) {
+  // Find the ComponentWell widgets in the code
+  final regex = RegExp(r'ComponentWell\s*\(.*?child:\s*', dotAll: true);
+  final matches = regex.allMatches(dartCode).toList();
+  if (matches.isEmpty || index >= matches.length) {
+    // No ComponentWell widget found or index out of bounds
+    return null;
+  }
+
+  // The ComponentWell widget we are actually interested in
+  final match = matches[index];
+
+  // We count the brackets to ensure we capture the entire content of 'child'
+  int openBrackets = 0;
+  int closeBrackets = 0;
+  int i = match.end;
+
+  // Iterate through the string to count braces and balance them
+  while (i < dartCode.length) {
+    if (dartCode[i] == '(') openBrackets++;
+    if (dartCode[i] == ')') closeBrackets++;
+
+    if (openBrackets == closeBrackets && openBrackets > 0) {
+      // As soon as the braces are balanced, we stop, as we have the full child widget
+      break;
+    }
+    i++;
+  }
+
+  // Get the content of the 'child' property
+  String extractedChild = dartCode.substring(match.end, i + 1);
+
+  // Take the last line indentation to apply it to the extracted child
+  final lastLineIndentation =
+      extractedChild.split('\n').last.replaceAll(RegExp(r'\S.*'), '');
+  return lastLineIndentation + extractedChild;
 }

--- a/example/lib/components/component_well.dart
+++ b/example/lib/components/component_well.dart
@@ -1,19 +1,51 @@
+import 'package:dart_style/dart_style.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:liquid/code_block.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
 import 'package:provider/provider.dart';
 
-class ComponentWell extends StatelessWidget {
+class ShowSourceCodeOptions {
+  /// The tag to look for in the source code.
+  /// The source code must contain a comment like this:
+  /// ```dart
+  /// /*begin demo:tag*/
+  /// // your code here
+  /// /*end demo:tag*/
+  /// ```
+  /// where `tag` is the value of this property.
+  /// The code between the `begin` and `end` comments will be displayed.
+  final String tag;
+
+  /// The path to the source code file. If not provided, it will be tried to
+  /// be inferred from the current route.
+  final String? path;
+
+  ShowSourceCodeOptions({required this.tag, this.path});
+}
+
+class ComponentWell extends StatefulWidget {
   final Widget child;
   final EdgeInsets? padding;
   final bool onSurface;
   final Color? color;
-  const ComponentWell(
-      {Key? key,
-      this.padding,
-      required this.child,
-      this.color,
-      this.onSurface = false})
-      : super(key: key);
+  final ShowSourceCodeOptions? showSourceCodeOptions;
+  const ComponentWell({
+    Key? key,
+    this.padding,
+    required this.child,
+    this.color,
+    this.onSurface = false,
+    this.showSourceCodeOptions,
+  }) : super(key: key);
+
+  @override
+  State<ComponentWell> createState() => _ComponentWellState();
+}
+
+class _ComponentWellState extends State<ComponentWell> {
+  bool isShowingSourceCode = false;
 
   @override
   Widget build(BuildContext context) {
@@ -21,18 +53,81 @@ class ComponentWell extends StatelessWidget {
     return Container(
         width: double.infinity,
         decoration: BoxDecoration(
-          color: color ?? (onSurface ? theme.surface : theme.background),
+          color: widget.color ??
+              (widget.onSurface ? theme.surface : theme.background),
           borderRadius: theme.radius(LdSize.m),
           border: Border.all(color: theme.border, width: theme.borderWidth),
         ),
-        padding: padding ??
-            const EdgeInsets.symmetric(
-              vertical: 32,
+        padding: widget.padding ??
+            EdgeInsets.symmetric(
+              vertical: widget.showSourceCodeOptions != null ? 16 : 32,
               horizontal: 16,
             ),
         child: Provider.value(
-          value: LdSurfaceInfo(isSurface: onSurface),
-          child: child,
+          value: LdSurfaceInfo(isSurface: widget.onSurface),
+          child: widget.showSourceCodeOptions != null
+              ? _buildChildWithSourceCode(context)
+              : widget.child,
         ));
+  }
+
+  /// Builds the child with a button to toggle between the demo and the source code.
+  Widget _buildChildWithSourceCode(BuildContext context) {
+    final _sourcePath = "lib${GoRouter.of(context).state?.pageKey.value}.dart";
+    return FutureBuilder<String>(
+      future: rootBundle.loadString(_sourcePath),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          if (snapshot.hasData) {
+            RegExp exp = RegExp(
+                r'/\*\s*begin demo:\s*' +
+                    widget.showSourceCodeOptions!.tag +
+                    r'\s*\*/(.*)\/\*\s*end demo:\s*' +
+                    widget.showSourceCodeOptions!.tag +
+                    r'\s*\*/',
+                dotAll: true);
+            var demoSource = exp
+                .firstMatch(snapshot.data!)
+                ?.group(1)
+                ?.trim()
+                // make it a valid dart statement by putting a semicolon at the end:
+                .replaceAll(RegExp(r',$'), ';');
+            if (demoSource != null) {
+              return Column(
+                children: [
+                  Align(
+                    alignment: Alignment.centerRight,
+                    child: LdButtonGhost(
+                      leading: Icon(isShowingSourceCode
+                          ? Icons.grid_view_outlined
+                          : Icons.code),
+                      child: Text(isShowingSourceCode
+                          ? "Show Demo"
+                          : "Show Source Code"),
+                      onPressed: () => setState(
+                        () => isShowingSourceCode = !isShowingSourceCode,
+                      ),
+                    ),
+                  ),
+                  Visibility(
+                      child: widget.child, visible: !isShowingSourceCode),
+                  Visibility(
+                    child: CodeBlock(
+                      expanded: true,
+                      code: DartFormatter(
+                        languageVersion: DartFormatter.latestLanguageVersion,
+                        experimentFlags: [],
+                      ).formatStatement(demoSource),
+                    ),
+                    visible: isShowingSourceCode,
+                  ),
+                ],
+              );
+            }
+          }
+        }
+        return widget.child;
+      },
+    );
   }
 }

--- a/example/lib/components/component_well.dart
+++ b/example/lib/components/component_well.dart
@@ -18,8 +18,9 @@ class ShowSourceCodeOptions {
   /// The code between the `begin` and `end` comments will be displayed.
   final String tag;
 
-  /// The path to the source code file. If not provided, it will be tried to
-  /// be inferred from the current route.
+  /// The path to the source code file, e.g. "lib/components/reactive_form.dart".
+  /// If no path is provided, it will be tried to be inferred from the current
+  /// route.
   final String? path;
 
   ShowSourceCodeOptions({required this.tag, this.path});
@@ -73,7 +74,8 @@ class _ComponentWellState extends State<ComponentWell> {
 
   /// Builds the child with a button to toggle between the demo and the source code.
   Widget _buildChildWithSourceCode(BuildContext context) {
-    final _sourcePath = "lib${GoRouter.of(context).state?.pageKey.value}.dart";
+    final _sourcePath = widget.showSourceCodeOptions?.path ??
+        "lib${GoRouter.of(context).state?.pageKey.value}.dart";
     return FutureBuilder<String>(
       future: rootBundle.loadString(_sourcePath),
       builder: (context, snapshot) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -53,6 +53,7 @@ flutter:
   assets:
     - liquid_flutter_icon.jpg
     - assets/
+    - lib/components/
 
   fonts:
     - family: Lato


### PR DESCRIPTION
Introduce an experimental option to display the original source code for working demos. Adds a "show source code" button in the top-right corner of the ComponentWell, allowing users to toggle between the demo view and its corresponding source code.

<img width="919" alt="image" src="https://github.com/user-attachments/assets/172f652b-154c-4e40-8cfb-0503a61d3446" />

<img width="919" alt="image" src="https://github.com/user-attachments/assets/23013c7e-5d6b-47d2-9643-73ca98d86353" />
