### PR TITLE
feat: add automatic retry mechanism for LdSubmit

### DIFF
--- a/example/lib/components/submit.dart
+++ b/example/lib/components/submit.dart
@@ -215,18 +215,18 @@ class _SubmitDemoState extends State<SubmitDemo> {
           ),
           LdBundle(
             children: [
-              const LdTextH("Automatic retries"),
+              const LdTextH("(Automatic) Retries"),
               const LdTextP(
-                "You can pass an LdSubmitAutomaticRetryConfig to the LdSubmitConfig to enable automatic retries. The delay between retries will increase exponentially.",
+                "You can pass an LdSubmitRetryConfig to the LdSubmitConfig to enable (automatic) retries, or to block the retry button for a certain amount of time before allowing the user to trigger it again. The delay between retries will increase exponentially.",
               ),
               ComponentWell(
                 child: LdSubmit(
                   config: LdSubmitConfig(
                     retryConfig: const LdSubmitRetryConfig(
-                      performAutomaticRetry: false,
+                      performAutomaticRetry: true,
                       disableRetryButton: true,
-                      maxRetryAttempts: 0,
-                      initialRetryCountdown: 0,
+                      maxRetryAttempts: 3,
+                      initialRetryCountdown: 3000,
                     ),
                     action: () {
                       return Future.delayed(

--- a/example/lib/components/submit.dart
+++ b/example/lib/components/submit.dart
@@ -222,9 +222,11 @@ class _SubmitDemoState extends State<SubmitDemo> {
               ComponentWell(
                 child: LdSubmit(
                   config: LdSubmitConfig(
-                    automaticRetry: const LdSubmitAutomaticRetryConfig(
-                      maxAutomaticRetryAttempts: 3,
-                      initialAutomaticRetryDelay: 3000,
+                    retryConfig: const LdSubmitRetryConfig(
+                      performAutomaticRetry: false,
+                      disableRetryButton: true,
+                      maxRetryAttempts: 0,
+                      initialRetryCountdown: 0,
                     ),
                     action: () {
                       return Future.delayed(

--- a/example/lib/components/submit.dart
+++ b/example/lib/components/submit.dart
@@ -220,13 +220,14 @@ class _SubmitDemoState extends State<SubmitDemo> {
                 "You can pass an LdSubmitRetryConfig to the LdSubmitConfig to enable (automatic) retries, or to block the retry button for a certain amount of time before allowing the user to trigger it again. The delay between retries will increase exponentially.",
               ),
               ComponentWell(
-                child: LdSubmit(
-                  config: LdSubmitConfig(
+                child: LdSubmit<void>(
+                  builder: const LdSubmitCenteredBuilder<void>(),
+                  config: LdSubmitConfig<void>(
                     retryConfig: const LdSubmitRetryConfig(
                       performAutomaticRetry: true,
-                      disableRetryButton: true,
-                      maxRetryAttempts: 3,
-                      initialRetryCountdown: 3000,
+                      disableRetryButton: false,
+                      maxAttempts: 4,
+                      initialRetryCountdown: Duration(seconds: 3),
                     ),
                     action: () {
                       return Future.delayed(

--- a/example/lib/components/submit.dart
+++ b/example/lib/components/submit.dart
@@ -213,6 +213,35 @@ class _SubmitDemoState extends State<SubmitDemo> {
               )
             ],
           ),
+          LdBundle(
+            children: [
+              const LdTextH("Automatic retries"),
+              const LdTextP(
+                "You can pass an LdSubmitAutomaticRetryConfig to the LdSubmitConfig to enable automatic retries. The delay between retries will increase exponentially.",
+              ),
+              ComponentWell(
+                child: LdSubmit(
+                  config: LdSubmitConfig(
+                    automaticRetry: const LdSubmitAutomaticRetryConfig(
+                      maxAutomaticRetryAttempts: 3,
+                      initialAutomaticRetryDelay: 3000,
+                    ),
+                    action: () {
+                      return Future.delayed(
+                        const Duration(seconds: 2),
+                        () {
+                          throw LdException(
+                            message: "Something went wrong",
+                            moreInfo: "Nothing actually happened",
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              )
+            ],
+          ),
           const LdBundle(
             children: [
               LdTextH("LdSubmitConfig"),

--- a/lib/liquid_flutter.dart
+++ b/lib/liquid_flutter.dart
@@ -70,6 +70,7 @@ export 'src/portal.dart';
 export 'src/submit/exception_more_info_button.dart';
 export 'src/submit/exception/exception_view.dart';
 export 'src/submit/exception/exception.dart';
+export 'src/submit/exception/retry_indicator.dart';
 export 'src/submit/submit_loading_indicator.dart';
 export 'src/submit/submit.dart';
 export 'src/submit/builders/centered_builder.dart';

--- a/lib/src/l10n/app_de.arb
+++ b/lib/src/l10n/app_de.arb
@@ -15,6 +15,7 @@
   "ok": "OK", 
   "refresh": "Aktualisieren",
   "retry": "Erneut versuchen",
+  "retryIn": "Erneuter Versuch in {seconds}s...",
   "searchAgain": "Erneut suchen",
   "selectDate": "Datum auswählen",
   "submit": "Absenden",

--- a/lib/src/l10n/app_en.arb
+++ b/lib/src/l10n/app_en.arb
@@ -11,6 +11,7 @@
   "errorOccurred": "An error occurred",
   "failed": "Failed",
   "retry": "Retry",
+  "retryIn": "Retry in {seconds}s...",
   "choose": "Choose",
   "submit": "Submit",
   "selectDate": "Select date",

--- a/lib/src/l10n/generated/liquid_localizations.dart
+++ b/lib/src/l10n/generated/liquid_localizations.dart
@@ -167,6 +167,12 @@ abstract class LiquidLocalizations {
   /// **'Retry'**
   String get retry;
 
+  /// No description provided for @retryIn.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry in {seconds}s...'**
+  String retryIn(Object seconds);
+
   /// No description provided for @choose.
   ///
   /// In en, this message translates to:

--- a/lib/src/l10n/generated/liquid_localizations_de.dart
+++ b/lib/src/l10n/generated/liquid_localizations_de.dart
@@ -43,6 +43,11 @@ class LiquidLocalizationsDe extends LiquidLocalizations {
   String get retry => 'Erneut versuchen';
 
   @override
+  String retryIn(Object seconds) {
+    return 'Erneuter Versuch in ${seconds}s...';
+  }
+
+  @override
   String get choose => 'Auswählen';
 
   @override

--- a/lib/src/l10n/generated/liquid_localizations_en.dart
+++ b/lib/src/l10n/generated/liquid_localizations_en.dart
@@ -43,6 +43,11 @@ class LiquidLocalizationsEn extends LiquidLocalizations {
   String get retry => 'Retry';
 
   @override
+  String retryIn(Object seconds) {
+    return 'Retry in ${seconds}s...';
+  }
+
+  @override
   String get choose => 'Choose';
 
   @override

--- a/lib/src/submit/builders/centered_builder.dart
+++ b/lib/src/submit/builders/centered_builder.dart
@@ -36,6 +36,7 @@ class LdSubmitCenteredBuilder<T> extends LdSubmitBuilder<T> {
                         exception: state.error!,
                         direction: Axis.vertical,
                         retry: controller.canRetry ? controller.trigger : null,
+                        retryState: controller.state.retryState,
                       )
               else if (state.type == LdSubmitStateType.idle)
                 submitButtonBuilder != null

--- a/lib/src/submit/builders/centered_builder.dart
+++ b/lib/src/submit/builders/centered_builder.dart
@@ -32,10 +32,23 @@ class LdSubmitCenteredBuilder<T> extends LdSubmitBuilder<T> {
               if (state.type == LdSubmitStateType.error)
                 errorBuilder != null
                     ? errorBuilder!(context, state.error!, controller)
-                    : LdExceptionView(
-                        exception: state.error!,
-                        direction: Axis.vertical,
-                        retry: controller.canRetry ? controller.trigger : null,
+                    : LdAutoSpace(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          LdExceptionView(
+                            exception: state.error!,
+                            direction: Axis.vertical,
+                            retry:
+                                controller.canRetry ? controller.trigger : null,
+                          ),
+                          if (controller.showRetryIndicator)
+                            LdExceptionRetryIndicator(
+                              attempt: state.attempt,
+                              remainingTime:
+                                  state.remainingRetryTime ?? Duration.zero,
+                              totalRetryTime: controller.totalRetryTime,
+                            ),
+                        ],
                       )
               else if (state.type == LdSubmitStateType.idle)
                 submitButtonBuilder != null

--- a/lib/src/submit/builders/centered_builder.dart
+++ b/lib/src/submit/builders/centered_builder.dart
@@ -36,7 +36,6 @@ class LdSubmitCenteredBuilder<T> extends LdSubmitBuilder<T> {
                         exception: state.error!,
                         direction: Axis.vertical,
                         retry: controller.canRetry ? controller.trigger : null,
-                        retryState: controller.state.retryState,
                       )
               else if (state.type == LdSubmitStateType.idle)
                 submitButtonBuilder != null

--- a/lib/src/submit/builders/dialog_builder.dart
+++ b/lib/src/submit/builders/dialog_builder.dart
@@ -56,7 +56,6 @@ class LdSubmitDialogBuilder<T> extends LdSubmitBuilder<T> {
             exception: controller.state.error!,
             direction: Axis.vertical,
             retry: controller.canRetry ? controller.trigger : null,
-            retryState: controller.state.retryState,
           ).padL();
   }
 

--- a/lib/src/submit/builders/dialog_builder.dart
+++ b/lib/src/submit/builders/dialog_builder.dart
@@ -56,6 +56,7 @@ class LdSubmitDialogBuilder<T> extends LdSubmitBuilder<T> {
             exception: controller.state.error!,
             direction: Axis.vertical,
             retry: controller.canRetry ? controller.trigger : null,
+            retryState: controller.state.retryState,
           ).padL();
   }
 

--- a/lib/src/submit/builders/dialog_builder.dart
+++ b/lib/src/submit/builders/dialog_builder.dart
@@ -50,13 +50,25 @@ class LdSubmitDialogBuilder<T> extends LdSubmitBuilder<T> {
     BuildContext context,
     LdSubmitController<T> controller,
   ) {
-    return errorBuilder != null
-        ? errorBuilder!(context, controller.state.error!, controller)
-        : LdExceptionView(
-            exception: controller.state.error!,
-            direction: Axis.vertical,
-            retry: controller.canRetry ? controller.trigger : null,
-          ).padL();
+    if (errorBuilder != null) {
+      return errorBuilder!(context, controller.state.error!, controller);
+    }
+
+    return LdAutoSpace(
+      children: [
+        LdExceptionView(
+          exception: controller.state.error!,
+          direction: Axis.vertical,
+          retry: controller.canRetry ? controller.trigger : null,
+        ),
+        if (controller.showRetryIndicator)
+          LdExceptionRetryIndicator(
+            attempt: controller.state.attempt,
+            remainingTime: controller.state.remainingRetryTime ?? Duration.zero,
+            totalRetryTime: controller.totalRetryTime,
+          ),
+      ],
+    );
   }
 
   @override

--- a/lib/src/submit/builders/inline_builder.dart
+++ b/lib/src/submit/builders/inline_builder.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
+
 import 'package:liquid_flutter/src/submit/builders/submit_button.dart';
 import 'package:provider/provider.dart';
 
@@ -40,10 +41,21 @@ class LdSubmitInlineBuilder<T> extends LdSubmitBuilder<T> {
               if (errorBuilder != null)
                 errorBuilder!(context, state.error!, controller)
               else
-                LdExceptionView(
-                  exception: state.error!,
-                  direction: Axis.horizontal,
-                  retry: controller.canRetry ? controller.trigger : null,
+                Row(
+                  children: [
+                    LdExceptionView(
+                      exception: state.error!,
+                      direction: Axis.horizontal,
+                      retry: controller.canRetry ? controller.trigger : null,
+                    ),
+                    if (controller.showRetryIndicator)
+                      LdExceptionRetryIndicator(
+                        attempt: controller.state.attempt,
+                        remainingTime: controller.state.remainingRetryTime ??
+                            Duration.zero,
+                        totalRetryTime: controller.totalRetryTime,
+                      ),
+                  ],
                 )
             else if (submitButtonBuilder != null)
               submitButtonBuilder!(context, controller)

--- a/lib/src/submit/builders/inline_builder.dart
+++ b/lib/src/submit/builders/inline_builder.dart
@@ -44,7 +44,6 @@ class LdSubmitInlineBuilder<T> extends LdSubmitBuilder<T> {
                   exception: state.error!,
                   direction: Axis.horizontal,
                   retry: controller.canRetry ? controller.trigger : null,
-                  retryState: controller.state.retryState,
                 )
             else if (submitButtonBuilder != null)
               submitButtonBuilder!(context, controller)

--- a/lib/src/submit/builders/inline_builder.dart
+++ b/lib/src/submit/builders/inline_builder.dart
@@ -44,6 +44,7 @@ class LdSubmitInlineBuilder<T> extends LdSubmitBuilder<T> {
                   exception: state.error!,
                   direction: Axis.horizontal,
                   retry: controller.canRetry ? controller.trigger : null,
+                  retryState: controller.state.retryState,
                 )
             else if (submitButtonBuilder != null)
               submitButtonBuilder!(context, controller)

--- a/lib/src/submit/exception/exception.dart
+++ b/lib/src/submit/exception/exception.dart
@@ -1,5 +1,35 @@
 import 'package:liquid_flutter/liquid_flutter.dart';
 
+/// The state of the retry mechanism.
+class LdExceptionRetryState {
+  /// The current retry count
+  final int retryCount;
+
+  /// The left time to retry in milliseconds.
+  /// It will be decremented each second by the [LdSubmitController].
+  final int delay;
+
+  LdExceptionRetryState({
+    required this.retryCount,
+    required this.delay,
+  });
+
+  copyWith({
+    int? retryCount,
+    int? delay,
+  }) {
+    return LdExceptionRetryState(
+      retryCount: retryCount ?? this.retryCount,
+      delay: delay ?? this.delay,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'LdExceptionRetryState(retryCount: $retryCount, delay: $delay)';
+  }
+}
+
 /// A renderable exception. Has a message, more info, and a type (LdHintType).
 /// Can also contain a stack trace as well as the flag that the action causing
 /// the exception can be retried.
@@ -8,6 +38,10 @@ class LdException extends Error {
   final String? moreInfo;
   final bool canRetry;
   final LdHintType type;
+
+  /// The state of the retry mechanism for this exception. Tracks the current
+  /// retry count and the left time to retry in milliseconds.
+  final LdExceptionRetryState? retryState;
 
   final dynamic exception;
 
@@ -21,5 +55,26 @@ class LdException extends Error {
     this.moreInfo,
     this.stackTrace,
     this.exception,
+    this.retryState,
   });
+
+  LdException copyWith({
+    String? message,
+    String? moreInfo,
+    bool? canRetry,
+    LdHintType? type,
+    LdExceptionRetryState? retryState,
+    dynamic exception,
+    StackTrace? stackTrace,
+  }) {
+    return LdException(
+      message: message ?? this.message,
+      moreInfo: moreInfo ?? this.moreInfo,
+      canRetry: canRetry ?? this.canRetry,
+      type: type ?? this.type,
+      retryState: retryState ?? this.retryState,
+      exception: exception ?? this.exception,
+      stackTrace: stackTrace ?? this.stackTrace,
+    );
+  }
 }

--- a/lib/src/submit/exception/exception.dart
+++ b/lib/src/submit/exception/exception.dart
@@ -7,7 +7,7 @@ class LdExceptionRetryState {
 
   /// The left time to retry in milliseconds.
   /// It will be decremented each second by the [LdSubmitController].
-  final int delay;
+  final Duration delay;
 
   LdExceptionRetryState({
     required this.retryCount,
@@ -16,7 +16,7 @@ class LdExceptionRetryState {
 
   copyWith({
     int? retryCount,
-    int? delay,
+    Duration? delay,
   }) {
     return LdExceptionRetryState(
       retryCount: retryCount ?? this.retryCount,
@@ -38,10 +38,7 @@ class LdException extends Error {
   final String? moreInfo;
   final bool canRetry;
   final LdHintType type;
-
-  /// The state of the retry mechanism for this exception. Tracks the current
-  /// retry count and the left time to retry in milliseconds.
-  final LdExceptionRetryState? retryState;
+  final int? attempt;
 
   final dynamic exception;
 
@@ -53,9 +50,9 @@ class LdException extends Error {
     this.canRetry = true,
     this.type = LdHintType.error,
     this.moreInfo,
+    this.attempt,
     this.stackTrace,
     this.exception,
-    this.retryState,
   });
 
   LdException copyWith({
@@ -63,7 +60,7 @@ class LdException extends Error {
     String? moreInfo,
     bool? canRetry,
     LdHintType? type,
-    LdExceptionRetryState? retryState,
+    int? attempt,
     dynamic exception,
     StackTrace? stackTrace,
   }) {
@@ -72,9 +69,13 @@ class LdException extends Error {
       moreInfo: moreInfo ?? this.moreInfo,
       canRetry: canRetry ?? this.canRetry,
       type: type ?? this.type,
-      retryState: retryState ?? this.retryState,
       exception: exception ?? this.exception,
       stackTrace: stackTrace ?? this.stackTrace,
     );
+  }
+
+  @override
+  String toString() {
+    return 'LdException(message: $message, moreInfo: $moreInfo, canRetry: $canRetry, type: $type, retryState: $attempt, exception: $exception, stackTrace: $stackTrace)';
   }
 }

--- a/lib/src/submit/exception/exception_mapper.dart
+++ b/lib/src/submit/exception/exception_mapper.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
 import 'package:provider/provider.dart';
@@ -49,47 +50,40 @@ class LdExceptionMapper {
     return context.read<LdExceptionMapper>();
   }
 
-  LdException? handle(dynamic e, {StackTrace? stackTrace}) {
+  LdException handle(
+    dynamic e, {
+    StackTrace? stackTrace,
+  }) {
     if (e is LdException) {
       return e;
     }
 
-    if (e is SocketException) {
-      return LdException(
-        message: localizations.networkError,
-        canRetry: true,
-        stackTrace: stackTrace,
-        moreInfo: e.toString(),
-        exception: e,
-      );
-    }
-
-    if (e is TimeoutException) {
-      return LdException(
-        message: localizations.timeoutError,
-        canRetry: true,
-        stackTrace: stackTrace,
-        moreInfo: e.toString(),
-        exception: e,
-      );
-    }
-
-    if (e is FormatException) {
-      return LdException(
-        message: localizations.formatError,
-        canRetry: true,
-        stackTrace: stackTrace,
-        moreInfo: e.toString(),
-        exception: e,
-      );
-    }
-
-    return LdException(
+    final exception = LdException(
       message: localizations.unknownError,
       canRetry: true,
       stackTrace: stackTrace,
       moreInfo: e.toString(),
       exception: e,
     );
+
+    if (e is SocketException) {
+      return exception.copyWith(
+        message: localizations.networkError,
+      );
+    }
+
+    if (e is TimeoutException) {
+      return exception.copyWith(
+        message: localizations.timeoutError,
+      );
+    }
+
+    if (e is FormatException) {
+      return exception.copyWith(
+        message: localizations.formatError,
+      );
+    }
+
+    return exception;
   }
 }

--- a/lib/src/submit/exception/exception_mapper.dart
+++ b/lib/src/submit/exception/exception_mapper.dart
@@ -18,15 +18,14 @@ class LdExceptionMapperProvider extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (exceptionMapper != null) {
-      // If an exception mapper is already provided, don't override it.
-      if (context.read<LdExceptionMapper?>() != null) {
-        return child;
-      }
-
       return Provider<LdExceptionMapper>.value(
         value: exceptionMapper!,
         child: child,
       );
+    }
+    // If an exception mapper is already provided, don't override it.
+    if (context.read<LdExceptionMapper?>() != null) {
+      return child;
     }
     final localizations = LiquidLocalizations.of(context);
     return Provider(

--- a/lib/src/submit/exception/exception_mapper.dart
+++ b/lib/src/submit/exception/exception_mapper.dart
@@ -43,7 +43,16 @@ class LdExceptionMapperProvider extends StatelessWidget {
 class LdExceptionMapper {
   final LiquidLocalizations localizations;
 
-  const LdExceptionMapper({required this.localizations});
+  /// A function that can be used to handle custom exceptions. If the function
+  /// returns a non-null LdException, it will be used instead of the default
+  /// exception mapper. Otherwise, the default exception mapper will be used.
+  /// This function will never be called if the exception is already an LdException.
+  final LdException? Function(dynamic e, {StackTrace? stackTrace})? onException;
+
+  const LdExceptionMapper({
+    required this.localizations,
+    this.onException,
+  });
 
   static LdExceptionMapper of(BuildContext context) {
     return context.read<LdExceptionMapper>();
@@ -55,6 +64,13 @@ class LdExceptionMapper {
   }) {
     if (e is LdException) {
       return e;
+    }
+
+    if (onException != null) {
+      final exception = onException!(e, stackTrace: stackTrace);
+      if (exception != null) {
+        return exception;
+      }
     }
 
     final exception = LdException(

--- a/lib/src/submit/exception/exception_view.dart
+++ b/lib/src/submit/exception/exception_view.dart
@@ -7,7 +7,6 @@ import 'package:provider/provider.dart';
 class LdExceptionView extends StatelessWidget {
   final LdException? exception;
   final VoidCallback? retry;
-  final LdSubmitRetryState? retryState;
 
   final Axis direction;
 
@@ -15,7 +14,6 @@ class LdExceptionView extends StatelessWidget {
     super.key,
     required this.exception,
     this.retry,
-    this.retryState,
     this.direction = Axis.vertical,
   });
 
@@ -51,18 +49,23 @@ class LdExceptionView extends StatelessWidget {
   }
 
   _buildRetryButton(BuildContext context) {
-    final isRetrying = (retryState?.delay ?? 0) > 0;
+    final isRetrying = (exception?.retryState?.delay ?? 0) > 0;
     final text = isRetrying
         ? LiquidLocalizations.of(context).retryIn(
-            Duration(milliseconds: retryState!.delay).inSeconds,
+            Duration(milliseconds: exception!.retryState!.delay).inSeconds,
           )
         : LiquidLocalizations.of(context).retry;
+    if (!isRetrying && exception?.canRetry == false) {
+      // hide the button if the exception can't be retried and there is no retry
+      // countdown.
+      return const SizedBox.shrink();
+    }
     return LdButton(
       child: Text(text),
       mode: LdButtonMode.filled,
       color: LdTheme.of(context).error,
-      disabled: isRetrying,
-      onPressed: retry!,
+      disabled: exception?.canRetry == false,
+      onPressed: retry ?? () {},
     );
   }
 
@@ -93,7 +96,10 @@ class LdExceptionView extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildDialogButton(context, moreInfo),
-            if (retry != null) ...[ldSpacerM, _buildRetryButton(context)],
+            if (retry != null || exception?.retryState != null) ...[
+              ldSpacerM,
+              _buildRetryButton(context)
+            ],
           ],
         )
       ],

--- a/lib/src/submit/exception/exception_view.dart
+++ b/lib/src/submit/exception/exception_view.dart
@@ -49,23 +49,17 @@ class LdExceptionView extends StatelessWidget {
   }
 
   _buildRetryButton(BuildContext context) {
-    final isRetrying = (exception?.retryState?.delay ?? 0) > 0;
-    final text = isRetrying
-        ? LiquidLocalizations.of(context).retryIn(
-            Duration(milliseconds: exception!.retryState!.delay).inSeconds,
-          )
-        : LiquidLocalizations.of(context).retry;
-    if (!isRetrying && exception?.canRetry == false) {
-      // hide the button if the exception can't be retried and there is no retry
-      // countdown.
-      return const SizedBox.shrink();
-    }
-    return LdButton(
-      child: Text(text),
-      mode: LdButtonMode.filled,
-      color: LdTheme.of(context).error,
-      disabled: exception?.canRetry == false,
-      onPressed: retry ?? () {},
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        LdButton(
+          child: Text(LiquidLocalizations.of(context).retry),
+          key: const Key('retry-button'),
+          mode: LdButtonMode.filled,
+          color: LdTheme.of(context).error,
+          onPressed: retry!,
+        ),
+      ],
     );
   }
 
@@ -96,10 +90,7 @@ class LdExceptionView extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             _buildDialogButton(context, moreInfo),
-            if (retry != null || exception?.retryState != null) ...[
-              ldSpacerM,
-              _buildRetryButton(context)
-            ],
+            if (retry != null) ...[ldSpacerM, _buildRetryButton(context)],
           ],
         )
       ],

--- a/lib/src/submit/exception/exception_view.dart
+++ b/lib/src/submit/exception/exception_view.dart
@@ -114,7 +114,10 @@ class LdExceptionView extends StatelessWidget {
           type: exception?.type ?? LdHintType.error,
           size: LdSize.l,
         ),
-        LdTextP(exception?.message ?? ""),
+        LdTextP(
+          exception?.message ?? "",
+          textAlign: TextAlign.center,
+        ),
         Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -134,11 +137,11 @@ class LdExceptionView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LdModalBuilder(
+      useRootNavigator: true,
       modal: LdModal(
         size: LdSize.xs,
         modalContent: (context) => LdExceptionDialog(
           error: exception,
-          close: () => Navigator.of(context).pop(),
         ),
       ),
       builder: (context, open) => switch (direction) {

--- a/lib/src/submit/exception/exception_view.dart
+++ b/lib/src/submit/exception/exception_view.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 class LdExceptionView extends StatelessWidget {
   final LdException? exception;
   final VoidCallback? retry;
+  final LdSubmitRetryState? retryState;
 
   final Axis direction;
 
@@ -14,6 +15,7 @@ class LdExceptionView extends StatelessWidget {
     super.key,
     required this.exception,
     this.retry,
+    this.retryState,
     this.direction = Axis.vertical,
   });
 
@@ -49,10 +51,17 @@ class LdExceptionView extends StatelessWidget {
   }
 
   _buildRetryButton(BuildContext context) {
+    final isRetrying = (retryState?.delay ?? 0) > 0;
+    final text = isRetrying
+        ? LiquidLocalizations.of(context).retryIn(
+            Duration(milliseconds: retryState!.delay).inSeconds,
+          )
+        : LiquidLocalizations.of(context).retry;
     return LdButton(
-      child: Text(LiquidLocalizations.of(context).retry),
+      child: Text(text),
       mode: LdButtonMode.filled,
       color: LdTheme.of(context).error,
+      disabled: isRetrying,
       onPressed: retry!,
     );
   }

--- a/lib/src/submit/exception/retry_indicator.dart
+++ b/lib/src/submit/exception/retry_indicator.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:liquid_flutter/liquid_flutter.dart';
+
+class LdExceptionRetryIndicator extends StatelessWidget {
+  final int attempt;
+
+  final Duration remainingTime;
+  final Duration totalRetryTime;
+
+  const LdExceptionRetryIndicator({
+    super.key,
+    required this.attempt,
+    required this.remainingTime,
+    required this.totalRetryTime,
+  });
+
+  double get progress =>
+      (remainingTime.inMilliseconds / totalRetryTime.inMilliseconds)
+          .clamp(0, 1);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(
+            value: progress,
+            strokeWidth: 2,
+            color: LdTheme.of(context).primaryColor,
+            backgroundColor: LdTheme.of(context).neutralShade(3),
+          ),
+        ),
+        ldSpacerS,
+        LdTextLs(
+          LiquidLocalizations.of(context).retryIn(remainingTime.inSeconds),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/submit/exception_dialog.dart
+++ b/lib/src/submit/exception_dialog.dart
@@ -4,10 +4,11 @@ import 'package:liquid_flutter/liquid_flutter.dart';
 /// Renders an LdException in a dialog
 class LdExceptionDialog extends StatelessWidget {
   final LdException? error;
-  final void Function() close;
 
-  const LdExceptionDialog(
-      {super.key, required this.error, required this.close});
+  const LdExceptionDialog({
+    super.key,
+    required this.error,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +30,7 @@ class LdExceptionDialog extends StatelessWidget {
           width: double.infinity,
           child: Text(LiquidLocalizations.of(context).close),
           onPressed: () {
-            close();
+            Navigator.of(context).pop();
           },
         )
       ],

--- a/lib/src/submit/exception_more_info_button.dart
+++ b/lib/src/submit/exception_more_info_button.dart
@@ -27,7 +27,6 @@ class LdExceptionMoreInfoButton extends StatelessWidget {
         noHeader: true,
         modalContent: (context) => LdExceptionDialog(
           error: error,
-          close: Navigator.of(context).pop,
         ),
         actions: (context) => [
           LdButtonGhost(

--- a/lib/src/submit/model/submit_config.dart
+++ b/lib/src/submit/model/submit_config.dart
@@ -5,8 +5,8 @@ import 'package:liquid_flutter/liquid_flutter.dart';
 /// Configuration for (automatic) retries of a submit action.
 class LdSubmitRetryConfig {
   final bool performAutomaticRetry;
-  final int maxRetryAttempts;
-  final int initialRetryCountdown;
+  final int maxAttempts;
+  final Duration initialRetryCountdown;
   final bool disableRetryButton;
 
   const LdSubmitRetryConfig({
@@ -14,14 +14,14 @@ class LdSubmitRetryConfig {
     /// the retry button for a certain amount of time.
     this.performAutomaticRetry = true,
 
-    /// The maximum number of retry attempts. After this number is reached, the
+    /// The maximum number of attempts. After this number is reached, the
     /// retry button will be hidden. If set to 0, the retry button will be hidden
     /// immediately.
-    this.maxRetryAttempts = 3,
+    this.maxAttempts = 3,
 
     /// The initial countdown in milliseconds for the retry button. This value
     /// will be doubled after each failed attempt.
-    this.initialRetryCountdown = 1000,
+    this.initialRetryCountdown = const Duration(seconds: 1),
 
     /// If set to true, the retry button will be disabled while the delay is
     /// counting down. Hence, the user cannot trigger a retry manually.
@@ -29,18 +29,18 @@ class LdSubmitRetryConfig {
   })  : assert(
           !performAutomaticRetry ||
               !disableRetryButton ||
-              initialRetryCountdown > 0,
+              initialRetryCountdown > Duration.zero,
           "If either performAutomaticRetry or disableRetryButton is true, the initialRetryCountdown must be greater than 0",
         ),
         assert(
-          maxRetryAttempts >= 0,
+          maxAttempts >= 0,
           "maxRetryAttempts must be greater than 0",
         );
 
   /// A configuration that does not allow any retries.
   factory LdSubmitRetryConfig.noRetries() => const LdSubmitRetryConfig(
         performAutomaticRetry: false,
-        maxRetryAttempts: 0,
+        maxAttempts: 0,
       );
 }
 
@@ -55,6 +55,7 @@ class LdSubmitConfig<T> {
   final bool? allowCancel;
   final LdSubmitCallback<T> action;
   final VoidCallback? onCanceled;
+
   final LdSubmitRetryConfig? retryConfig;
 
   const LdSubmitConfig({

--- a/lib/src/submit/model/submit_config.dart
+++ b/lib/src/submit/model/submit_config.dart
@@ -36,6 +36,12 @@ class LdSubmitRetryConfig {
           maxRetryAttempts >= 0,
           "maxRetryAttempts must be greater than 0",
         );
+
+  /// A configuration that does not allow any retries.
+  factory LdSubmitRetryConfig.noRetries() => const LdSubmitRetryConfig(
+        performAutomaticRetry: false,
+        maxRetryAttempts: 0,
+      );
 }
 
 /// A configuration for a submit action.

--- a/lib/src/submit/model/submit_config.dart
+++ b/lib/src/submit/model/submit_config.dart
@@ -2,6 +2,16 @@ import 'dart:ui';
 
 import 'package:liquid_flutter/liquid_flutter.dart';
 
+class LdSubmitAutomaticRetryConfig {
+  final int maxAutomaticRetryAttempts;
+  final int initialAutomaticRetryDelay;
+
+  const LdSubmitAutomaticRetryConfig({
+    this.maxAutomaticRetryAttempts = 3,
+    this.initialAutomaticRetryDelay = 1000,
+  });
+}
+
 /// A configuration for a submit action.
 class LdSubmitConfig<T> {
   final String? loadingText;
@@ -14,6 +24,7 @@ class LdSubmitConfig<T> {
   final bool? allowCancel;
   final LdSubmitCallback<T> action;
   final VoidCallback? onCanceled;
+  final LdSubmitAutomaticRetryConfig? automaticRetry;
 
   const LdSubmitConfig({
     /// The text to display when the action is loading
@@ -42,6 +53,10 @@ class LdSubmitConfig<T> {
 
     /// The timeout for the action
     this.timeout = const Duration(seconds: 10),
+
+    /// The configuration for automatic retries
+    /// If null, automatic retries are disabled
+    this.automaticRetry,
 
     /// The action to trigger that will return  T
     required this.action,

--- a/lib/src/submit/model/submit_config.dart
+++ b/lib/src/submit/model/submit_config.dart
@@ -2,21 +2,46 @@ import 'dart:ui';
 
 import 'package:liquid_flutter/liquid_flutter.dart';
 
-class LdSubmitAutomaticRetryConfig {
-  final int maxAutomaticRetryAttempts;
-  final int initialAutomaticRetryDelay;
+/// Configuration for (automatic) retries of a submit action.
+class LdSubmitRetryConfig {
+  final bool performAutomaticRetry;
+  final int maxRetryAttempts;
+  final int initialRetryCountdown;
+  final bool disableRetryButton;
 
-  const LdSubmitAutomaticRetryConfig({
-    this.maxAutomaticRetryAttempts = 3,
-    this.initialAutomaticRetryDelay = 1000,
-  });
+  const LdSubmitRetryConfig({
+    /// If set to false, you can still use [LdSubmitRetryConfig] in order to block
+    /// the retry button for a certain amount of time.
+    this.performAutomaticRetry = true,
+
+    /// The maximum number of retry attempts. After this number is reached, the
+    /// retry button will be hidden. If set to 0, the retry button will be hidden
+    /// immediately.
+    this.maxRetryAttempts = 3,
+
+    /// The initial countdown in milliseconds for the retry button. This value
+    /// will be doubled after each failed attempt.
+    this.initialRetryCountdown = 1000,
+
+    /// If set to true, the retry button will be disabled while the delay is
+    /// counting down. Hence, the user cannot trigger a retry manually.
+    this.disableRetryButton = false,
+  })  : assert(
+          !performAutomaticRetry ||
+              !disableRetryButton ||
+              initialRetryCountdown > 0,
+          "If either performAutomaticRetry or disableRetryButton is true, the initialRetryCountdown must be greater than 0",
+        ),
+        assert(
+          maxRetryAttempts >= 0,
+          "maxRetryAttempts must be greater than 0",
+        );
 }
 
 /// A configuration for a submit action.
 class LdSubmitConfig<T> {
   final String? loadingText;
   final String? submitText;
-  final bool? allowRetry;
   final bool? allowResubmit;
   final bool withHaptics;
   final bool autoTrigger;
@@ -24,7 +49,7 @@ class LdSubmitConfig<T> {
   final bool? allowCancel;
   final LdSubmitCallback<T> action;
   final VoidCallback? onCanceled;
-  final LdSubmitAutomaticRetryConfig? automaticRetry;
+  final LdSubmitRetryConfig? retryConfig;
 
   const LdSubmitConfig({
     /// The text to display when the action is loading
@@ -32,9 +57,6 @@ class LdSubmitConfig<T> {
 
     /// The text to display on the button
     this.submitText,
-
-    /// Whether to allow retrying the action when it fails
-    this.allowRetry,
 
     /// Whether to allow resubmitting the action after it has succeeded
     this.allowResubmit,
@@ -54,9 +76,10 @@ class LdSubmitConfig<T> {
     /// The timeout for the action
     this.timeout = const Duration(seconds: 10),
 
-    /// The configuration for automatic retries
-    /// If null, automatic retries are disabled
-    this.automaticRetry,
+    /// The configuration for (automatic) retries
+    /// If null, the user can manually trigger a retry as often as they want,
+    /// but no automatic retries will be performed.
+    this.retryConfig,
 
     /// The action to trigger that will return  T
     required this.action,

--- a/lib/src/submit/model/submit_controller.dart
+++ b/lib/src/submit/model/submit_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
@@ -87,8 +88,13 @@ class LdSubmitController<T> {
       // Retry logic if automatic retries are configured
       if (config.automaticRetry != null) {
         final retryCount = (state.retryState?.retryCount ?? 0) + 1;
-        final retryDelay = config.automaticRetry!.initialAutomaticRetryDelay *
-            (1 << (retryCount - 1)); // Exponential backoff delay
+        final retryDelay =
+            // Start with some jitter to avoid thundering herd
+            Random().nextInt(1500) +
+                // Calculate the delay based on the initial delay and the retry
+                // count, following an exponential backoff strategy
+                config.automaticRetry!.initialAutomaticRetryDelay *
+                    (1 << (retryCount - 1));
         final shouldRetry =
             retryCount <= config.automaticRetry!.maxAutomaticRetryAttempts;
 

--- a/lib/src/submit/model/submit_controller.dart
+++ b/lib/src/submit/model/submit_controller.dart
@@ -138,9 +138,6 @@ class LdSubmitController<T> {
         LdSubmitState(
           type: LdSubmitStateType.error,
           error: exception,
-          retryState: state.retryState?.copyWith(
-            delay: 0,
-          ),
         ),
       );
     }

--- a/lib/src/submit/model/submit_state.dart
+++ b/lib/src/submit/model/submit_state.dart
@@ -4,16 +4,62 @@ class LdSubmitState<T> {
   LdSubmitState({
     required LdSubmitStateType type,
     LdException? error,
+    int attempt = 0,
+    Duration? remainingRetryTime,
     T? result,
   })  : _type = type,
         _error = error,
+        _attempt = attempt,
+        _remainingRetryTime = remainingRetryTime,
         _result = result;
 
   final LdSubmitStateType _type;
   final LdException? _error;
   final T? _result;
 
+  final int _attempt;
+
+  final Duration? _remainingRetryTime;
+
+  /// The number of attempts made. Will reset to 0 if the submit action is
+  /// successful.
+  int get attempt => _attempt;
+
+  /// The remaining duration to retry. Will be null if no next retry is planned.
+  Duration? get remainingRetryTime => _remainingRetryTime;
+
+  /// The type of the submit state.
   LdSubmitStateType get type => _type;
+
+  /// The error that occurred during the submit action.
   LdException? get error => _error;
+
+  /// The result of the submit action. Only is not null if [type] is
+  /// [LdSubmitStateType.success].
   T? get result => _result;
+
+  @override
+  String toString() {
+    return "LdSubmitState( \n"
+        "type: $_type, \n"
+        "error: $_error, \n"
+        "result: $_result, \n"
+        "attempt: $_attempt)";
+  }
+
+  LdSubmitState<T> copyWith({
+    LdSubmitStateType? type,
+    LdException? error,
+    int? attempt,
+    Duration? remainingRetryTime,
+    T? result,
+  }) {
+    return LdSubmitState<T>(
+      type: type ?? _type,
+      error: error ?? _error,
+      attempt: attempt ?? _attempt,
+      remainingRetryTime: remainingRetryTime ?? _remainingRetryTime,
+      result: result ?? _result,
+    );
+  }
 }

--- a/lib/src/submit/model/submit_state.dart
+++ b/lib/src/submit/model/submit_state.dart
@@ -5,15 +5,47 @@ class LdSubmitState<T> {
     required LdSubmitStateType type,
     LdException? error,
     T? result,
+    LdSubmitRetryState? retryState,
   })  : _type = type,
         _error = error,
-        _result = result;
+        _result = result,
+        _retryState = retryState;
 
   final LdSubmitStateType _type;
   final LdException? _error;
   final T? _result;
+  final LdSubmitRetryState? _retryState;
 
   LdSubmitStateType get type => _type;
   LdException? get error => _error;
   T? get result => _result;
+
+  /// Typically, when a retry attempt is in progress, [type] will be [LdSubmitStateType.loading].
+  /// While we are waiting for a new retry, [type] will be [LdSubmitStateType.error].
+  LdSubmitRetryState? get retryState => _retryState;
+}
+
+/// The state of the retry mechanism.
+class LdSubmitRetryState {
+  /// The current retry count
+  final int retryCount;
+
+  /// The left time to retry in milliseconds.
+  /// It will be decremented each second by the [LdSubmitController].
+  final int delay;
+
+  LdSubmitRetryState({
+    required this.retryCount,
+    required this.delay,
+  });
+
+  copyWith({
+    int? retryCount,
+    int? delay,
+  }) {
+    return LdSubmitRetryState(
+      retryCount: retryCount ?? this.retryCount,
+      delay: delay ?? this.delay,
+    );
+  }
 }

--- a/lib/src/submit/model/submit_state.dart
+++ b/lib/src/submit/model/submit_state.dart
@@ -5,47 +5,15 @@ class LdSubmitState<T> {
     required LdSubmitStateType type,
     LdException? error,
     T? result,
-    LdSubmitRetryState? retryState,
   })  : _type = type,
         _error = error,
-        _result = result,
-        _retryState = retryState;
+        _result = result;
 
   final LdSubmitStateType _type;
   final LdException? _error;
   final T? _result;
-  final LdSubmitRetryState? _retryState;
 
   LdSubmitStateType get type => _type;
   LdException? get error => _error;
   T? get result => _result;
-
-  /// Typically, when a retry attempt is in progress, [type] will be [LdSubmitStateType.loading].
-  /// While we are waiting for a new retry, [type] will be [LdSubmitStateType.error].
-  LdSubmitRetryState? get retryState => _retryState;
-}
-
-/// The state of the retry mechanism.
-class LdSubmitRetryState {
-  /// The current retry count
-  final int retryCount;
-
-  /// The left time to retry in milliseconds.
-  /// It will be decremented each second by the [LdSubmitController].
-  final int delay;
-
-  LdSubmitRetryState({
-    required this.retryCount,
-    required this.delay,
-  });
-
-  copyWith({
-    int? retryCount,
-    int? delay,
-  }) {
-    return LdSubmitRetryState(
-      retryCount: retryCount ?? this.retryCount,
-      delay: delay ?? this.delay,
-    );
-  }
 }

--- a/test/submit_test.dart
+++ b/test/submit_test.dart
@@ -202,7 +202,7 @@ void main() {
     expect(find.textContaining("Retry in"), findsOneWidget);
     completer = Completer<int>();
     // wait a bit more until the retry happens
-    await tester.pump(const Duration(milliseconds: 1500));
+    await tester.pump(const Duration(milliseconds: 3000));
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
     expect(find.text("Loading..."), findsOneWidget);
 
@@ -221,12 +221,12 @@ void main() {
     // Third retry
     completer.completeError(Exception('Error'));
     // third retry will happen after 4 seconds, so we check if the "Retry in"
-    // text is still there after 3 seconds
-    await tester.pump(const Duration(milliseconds: 3000));
+    // text is still there after 3.5 seconds
+    await tester.pump(const Duration(milliseconds: 3500));
     expect(find.textContaining("Retry in"), findsOneWidget);
     completer = Completer<int>();
     // wait a bit more until the retry happens
-    await tester.pump(const Duration(milliseconds: 5000));
+    await tester.pump(const Duration(milliseconds: 3000));
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
     expect(find.text("Loading..."), findsOneWidget);
 


### PR DESCRIPTION
- Add `LdSubmitRetryState` and `LdSubmitAutomaticRetryConfig` classes for managing retry state and configuration.
- Update `LdSubmitConfig` to accept automatic retry configurations.
- Modify `_trigger` method in `LdSubmitController` to handle retries with exponential backoff.
- Enhance `LdExceptionView` to display retry countdown and disable retry button while retrying.
- Integrate localization for retry messages in both English and German.
- Update example to demonstrate automatic retry functionality.

<img width="919" alt="image" src="https://github.com/user-attachments/assets/29eba621-8b18-488f-84c7-e8825abef74e" />
