### PR TITLE
feat!: add URL handling in LdMasterDetail using ShellRoutes

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -60,7 +60,7 @@ jobs:
           API_CHANGELOG=$(dart ./generators/lib/doc_comparator/doc_comparator.dart \
           ./lib/documentation.dart origin/main:./lib/documentation.dart)
 
-          API_CHANGE_TYPE=$(echo "$API_CHANGELOG" | tail -n 1 | awk '{print $NF}')
+          API_CHANGE_TYPE=$(echo "$API_CHANGELOG" | head -n 1 | grep -oE "major|minor|patch")
           echo "API_CHANGE_TYPE=$API_CHANGE_TYPE" >> $GITHUB_ENV
           {
             echo 'API_CHANGELOG<<EOF'

--- a/example/lib/components/master_detail.dart
+++ b/example/lib/components/master_detail.dart
@@ -126,19 +126,10 @@ class _MasterDetailDemoState extends State<MasterDetailDemo> {
             child: LdCard(
               padding: EdgeInsets.zero,
               expandChild: true,
-              child: LdMasterDetail<int>(
+              child: LdMasterDetail(
                 layoutMode: _layoutMode,
                 detailPresentationMode: _presentationMode,
                 builder: ExampleBuilder<int>(_paginator),
-                detailsUrlBuilder: ({item, required uri}) {
-                  return uri.replace(
-                    queryParameters:
-                        item == null ? {} : {"item": item.toString()},
-                  );
-                },
-                detailsUrlParser: (uri) {
-                  return int.parse(uri.queryParameters["item"]!);
-                },
               ),
             ),
           ),

--- a/example/lib/router.dart
+++ b/example/lib/router.dart
@@ -1,28 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:liquid/chemical_screen.dart';
-import 'package:liquid/components/context_menu.dart';
-import 'package:liquid/components/date_time_pickers.dart';
-import 'package:liquid/components/indicator.dart';
-import 'package:liquid/components/reveal.dart';
-import 'package:liquid/components/runner.dart';
 import 'package:liquid/components/autospace.dart';
 import 'package:liquid/components/button.dart';
 import 'package:liquid/components/card.dart';
 import 'package:liquid/components/choose.dart';
-
+import 'package:liquid/components/context_menu.dart';
+import 'package:liquid/components/date_time_pickers.dart';
 import 'package:liquid/components/drawer.dart';
 import 'package:liquid/components/icons.dart';
+import 'package:liquid/components/indicator.dart';
 import 'package:liquid/components/list.dart';
 import 'package:liquid/components/list_full_screen.dart';
-
 import 'package:liquid/components/loader.dart';
 import 'package:liquid/components/master_detail.dart';
 import 'package:liquid/components/material.dart';
+import 'package:liquid/components/modal.dart';
 import 'package:liquid/components/orb.dart';
 import 'package:liquid/components/radio.dart';
+import 'package:liquid/components/reveal.dart';
+import 'package:liquid/components/runner.dart';
 import 'package:liquid/components/select.dart';
-import 'package:liquid/components/modal.dart';
 import 'package:liquid/components/slider.dart';
 import 'package:liquid/components/spring.dart';
 import 'package:liquid/components/submit.dart';
@@ -37,9 +35,7 @@ import 'package:liquid/demos/typography_documentation.dart';
 import 'package:liquid/home.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
 
-import 'window/app_scaffold.dart';
 import 'components/accordion.dart';
-
 import 'components/badge.dart';
 import 'components/breadcrumb.dart';
 import 'components/checkbox.dart';
@@ -50,6 +46,7 @@ import 'components/input.dart';
 import 'components/notification.dart';
 import 'components/table.dart';
 import 'components/tag.dart';
+import 'window/app_scaffold.dart';
 
 class AppRouter {
   AppRouter();
@@ -242,10 +239,14 @@ class AppRouter {
             pageBuilder: (context, state) => NoTransitionPage<void>(
                 key: state.pageKey, child: const Spring()),
           ),
-          GoRoute(
-            path: "/components/master-detail",
-            pageBuilder: (context, state) => NoTransitionPage<void>(
-                key: state.pageKey, child: const MasterDetailDemo()),
+          LdMasterDetail.createShellRoute<int>(
+            childBuilder: (context, state) => const MasterDetailDemo(),
+            routeConfig: LdMasterDetailShellRouteConfig<int>(
+              basePath: "/components/master-detail",
+              detailPath: "detail/:id",
+              itemProvider: (id) => int.tryParse(id),
+              itemIdGetter: (item) => item.toString(),
+            ),
           ),
           GoRoute(
             path: "/components/notification",

--- a/example/lib/router.dart
+++ b/example/lib/router.dart
@@ -240,7 +240,7 @@ class AppRouter {
                 key: state.pageKey, child: const Spring()),
           ),
           LdMasterDetail.createShellRoute<int>(
-            childBuilder: (context, state) => const MasterDetailDemo(),
+            child: const MasterDetailDemo(),
             routeConfig: LdMasterDetailShellRouteConfig<int>(
               basePath: "/components/master-detail",
               detailPath: "detail/:id",

--- a/generators/lib/doc_comparator/doc_comparator.dart
+++ b/generators/lib/doc_comparator/doc_comparator.dart
@@ -32,7 +32,7 @@ void main(List<String> args) async {
   final magnitude = mag != null
       ? ApiChangeMagnitude.values
           .firstWhereOrNull((element) => element.toString().contains(mag))
-      : null;
+      : ApiChangeMagnitude.patch;
 
   final positionalArgs =
       args.where((element) => !element.startsWith('-')).toList();

--- a/lib/src/master_detail.dart
+++ b/lib/src/master_detail.dart
@@ -138,18 +138,25 @@ class LdMasterDetail<T> extends StatefulWidget {
   /// Helper function to create a router configuration that uses this component
   /// as a shell route.
   static ShellRoute createShellRoute<T>({
-    required Widget Function(
-      BuildContext context,
-      GoRouterState state,
-    ) childBuilder,
+    required Widget child,
     required LdMasterDetailShellRouteConfig<T> routeConfig,
+    Page Function(BuildContext context, GoRouterState state, Widget child)?
+        pageBuilder,
   }) {
+    pageBuilder ??= (context, state, child) => NoTransitionPage<void>(
+          key: state.pageKey,
+          child: child,
+        );
     return ShellRoute(
-      pageBuilder: (context, state, child) => NoTransitionPage<void>(
-        key: state.pageKey,
-        child: Provider<LdMasterDetailShellRouteConfig<T>?>.value(
-          value: routeConfig, // Provide the routeConfig to LdMasterDetail
-          child: childBuilder(context, state),
+      // _ is the placeholder from the dummy widgets of the routes
+      pageBuilder: (context, state, _) => pageBuilder!(
+        context,
+        state,
+        // We wrap the child in a provider to make the route configuration
+        // available to LdMasterDetail
+        Provider<LdMasterDetailShellRouteConfig<T>?>.value(
+          value: routeConfig,
+          child: child,
         ),
       ),
 

--- a/lib/src/modal/modal.dart
+++ b/lib/src/modal/modal.dart
@@ -1,5 +1,6 @@
 import 'dart:io' if (dart.library.io) 'dart:io';
 import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -228,6 +229,7 @@ class LdModal {
           mode: title != null ? LdButtonMode.ghost : LdButtonMode.vague,
           child: const Icon(Icons.clear),
           onPressed: () {
+            onDismiss?.call();
             Navigator.of(context).pop();
           },
         );
@@ -438,6 +440,8 @@ class LdModal {
       pageListBuilderNotifier: ValueNotifier(
         (context) => _getPageList(context),
       ),
+      onModalDismissedWithBarrierTap: onDismiss,
+      onModalDismissedWithDrag: onDismiss,
     );
   }
 
@@ -452,6 +456,11 @@ class LdModal {
       ),
       child: PopScope(
         canPop: userCanDismiss,
+        onPopInvokedWithResult: (didPop, result) {
+          if (didPop) {
+            onDismiss?.call();
+          }
+        },
         child: LdPortal(child: child),
       ),
     );


### PR DESCRIPTION
- fix: actually call onDismiss callback, when a modal is dismissed
- feat: refactor LdMasterDetail routing to utilize GoRouter's ShellRoute

This removes `detailsUrlBuilder` and `detailsUrlParser` from `LdMasterDetail` again.