### PR TITLE
fix: resolve issues with api change detection and corresponding workflow

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,7 +58,7 @@ jobs:
         id: detect_change_type
         run: |
           API_CHANGELOG=$(dart ./generators/lib/doc_comparator/doc_comparator.dart \
-          HEAD:./lib/documentation.dart origin/main:./lib/documentation.dart -v)
+          ./lib/documentation.dart origin/main:./lib/documentation.dart -v)
 
           API_CHANGE_TYPE=$(echo "$API_CHANGELOG" | tail -n 1 | awk '{print $NF}')
           echo "API_CHANGE_TYPE=$API_CHANGE_TYPE" >> $GITHUB_ENV

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -85,6 +85,8 @@ jobs:
         run: |
           IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<< "$PREVIOUS_VERSION"
           IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "${{ steps.get_new_version.outputs.result }}"
+          echo "Old version: $PREVIOUS_VERSION"
+          echo "New version: ${{ steps.get_new_version.outputs.result }}"
 
           if [[ "$NEW_MAJOR" -gt "$OLD_MAJOR" ]]; then
             DETECTED_CHANGE="major"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,7 +58,7 @@ jobs:
         id: detect_change_type
         run: |
           API_CHANGELOG=$(dart ./generators/lib/doc_comparator/doc_comparator.dart \
-          ./lib/documentation.dart origin/main:./lib/documentation.dart -v)
+          ./lib/documentation.dart origin/main:./lib/documentation.dart)
 
           API_CHANGE_TYPE=$(echo "$API_CHANGELOG" | tail -n 1 | awk '{print $NF}')
           echo "API_CHANGE_TYPE=$API_CHANGE_TYPE" >> $GITHUB_ENV

--- a/generators/lib/doc_comparator/api_change.dart
+++ b/generators/lib/doc_comparator/api_change.dart
@@ -1,39 +1,131 @@
+import 'package:liquid_generators/doc_items.dart';
+
 /// The type of change that was detected in the API.
 /// A [patch] change is a change that does not break the API.
 /// A [minor] change is a change that adds new features to the API or introduces
 /// backwards-compatible changes.
 /// A [major] change is a change that breaks the API or removes features.
-enum ApiChangeType {
+enum ApiChangeMagnitude {
   patch,
   minor,
   major;
 
-  ApiChangeType atLeast(ApiChangeType other) {
+  ApiChangeMagnitude atLeast(ApiChangeMagnitude other) {
     return index >= other.index ? this : other;
   }
 
-  ApiChangeType atMost(ApiChangeType other) {
+  ApiChangeMagnitude atMost(ApiChangeMagnitude other) {
     return index <= other.index ? this : other;
   }
+}
+
+enum ApiChangeOperation {
+  added,
+  removed,
+  typeChanged,
+  // Constructor Parameter changes:
+  becameOptional,
+  becameRequired,
+  becameNamed,
+  becamePositional,
+  becameNullUnsafe,
+  becameNullSafe,
+  becamePrivate,
+  becamePublic,
 }
 
 /// A change description in the API that belongs to a specific component.
 class ApiChange {
   final String component;
-  final String description;
-  final ApiChangeType type;
+  final ApiChangeOperation operation;
 
-  ApiChange({
+  ApiChange._({
     required this.component,
-    required this.description,
-    required this.type,
+    required this.operation,
   });
 
-  ApiChange atMost(ApiChangeType other) {
-    return ApiChange(
-      component: component,
-      description: description,
-      type: type.atMost(other),
-    );
+  ApiChangeMagnitude getMagnitude() {
+    if (component.startsWith('_')) {
+      // if the component is private, it's a patch change
+      return ApiChangeMagnitude.patch;
+    }
+    if (operation == ApiChangeOperation.added) {
+      // if a parameter, class or property was added, it's usually a minor
+      // change (unless it's private)
+      return ApiChangeMagnitude.minor;
+    }
+    // if we don't know the magnitude, we default to major (better to be safe)
+    return ApiChangeMagnitude.major;
+  }
+}
+
+class ComponentApiChange extends ApiChange {
+  ComponentApiChange({
+    required super.component,
+    required super.operation,
+  }) : super._();
+}
+
+class PropertyApiChange extends ApiChange {
+  final Property property;
+
+  PropertyApiChange({
+    required super.component,
+    required super.operation,
+    required this.property,
+  }) : super._();
+
+  @override
+  ApiChangeMagnitude getMagnitude() {
+    if (property.name.startsWith('_')) {
+      // if the property is private, it's a patch change
+      return ApiChangeMagnitude.patch;
+    }
+    return super.getMagnitude();
+  }
+}
+
+class ConstructorApiChange extends ApiChange {
+  final Constructor constructor;
+
+  ConstructorApiChange({
+    required super.component,
+    required super.operation,
+    required this.constructor,
+  }) : super._();
+
+  @override
+  ApiChangeMagnitude getMagnitude() {
+    if (constructor.name.startsWith('_')) {
+      // if the constructor is private, it's a patch change
+      return ApiChangeMagnitude.patch;
+    }
+    return super.getMagnitude();
+  }
+}
+
+class ConstructorParameterApiChange extends ApiChange {
+  final Constructor constructor;
+  final Parameter parameter;
+
+  ConstructorParameterApiChange({
+    required super.component,
+    required super.operation,
+    required this.constructor,
+    required this.parameter,
+  }) : super._();
+
+  @override
+  ApiChangeMagnitude getMagnitude() {
+    if (constructor.name.startsWith('_') || parameter.name.startsWith('_')) {
+      // if the constructor or parameter is private, it's a patch change
+      return ApiChangeMagnitude.patch;
+    }
+    if (operation == ApiChangeOperation.becameNullSafe ||
+        operation == ApiChangeOperation.becameOptional ||
+        (operation == ApiChangeOperation.removed && !parameter.required)) {
+      return ApiChangeMagnitude.minor;
+    }
+    return super.getMagnitude();
   }
 }

--- a/generators/lib/doc_comparator/api_change_formatter.dart
+++ b/generators/lib/doc_comparator/api_change_formatter.dart
@@ -1,0 +1,191 @@
+import 'package:collection/collection.dart';
+import 'package:liquid_generators/doc_comparator/api_change.dart';
+
+/// Formatter to display API changes in a hierarchical format
+class ApiChangeFormatter {
+  final List<ApiChange> changes;
+  final ApiChangeMagnitude? showUpToMagnitude;
+
+  ApiChangeFormatter(
+    this.changes, {
+    /// If set to null, no changelog will be shown.
+    /// If set to [ApiChangeMagnitude.major], only major changes will be shown.
+    /// If set to [ApiChangeMagnitude.minor], major and minor changes will be shown.
+    /// If set to [ApiChangeMagnitude.patch], all changes will be shown.
+    this.showUpToMagnitude = ApiChangeMagnitude.patch,
+  });
+
+  String format() {
+    var highestMagnitude = ApiChangeMagnitude.patch;
+    final changelogBuffer = StringBuffer();
+
+    // Group changes by magnitude and process them in order
+    final changesByMagnitude = _groupByMagnitude();
+    final magnitudes = [
+      ApiChangeMagnitude.major,
+      ApiChangeMagnitude.minor,
+      ApiChangeMagnitude.patch
+    ];
+    for (final magnitude in magnitudes) {
+      if (!changesByMagnitude.containsKey(magnitude)) continue;
+      highestMagnitude = highestMagnitude.atLeast(magnitude);
+
+      if (showUpToMagnitude == null ||
+          magnitude.index < showUpToMagnitude!.index) {
+        // We do not want to print this magnitude
+        continue;
+      }
+
+      changelogBuffer.writeln("\n---\n");
+      changelogBuffer.writeln(_getMagnitudeHeader(magnitude));
+
+      // Group by component and process them in alphabetical order
+      final componentChanges =
+          _groupByComponent(changesByMagnitude[magnitude]!);
+      final sortedComponents = componentChanges.keys.toList()..sort();
+      for (final component in sortedComponents) {
+        changelogBuffer.writeln();
+        changelogBuffer.writeln('**$component**');
+
+        // Group by category (i.e. type, operation, etc.) and process them
+        final categorizedChanges =
+            _groupByChangeCategory(componentChanges[component]!);
+        final categories = categorizedChanges.keys.toList();
+        for (final category in categories) {
+          final changes = categorizedChanges[category]!;
+          changelogBuffer.writeln("- ${_formatChanges(changes)}");
+        }
+      }
+    }
+
+    return "${_getHighestMagnitudeText(highestMagnitude)}\n$changelogBuffer";
+  }
+
+  // Group changes by magnitude
+  Map<ApiChangeMagnitude, List<ApiChange>> _groupByMagnitude() {
+    return groupBy(changes, (change) => change.getMagnitude());
+  }
+
+  // Group changes by component
+  Map<String, List<ApiChange>> _groupByComponent(List<ApiChange> changes) {
+    return groupBy(changes, (change) => change.component);
+  }
+
+  // Group changes by generating a change category that considers the type,
+  // operation (and other properties if needed)
+  Map<int, List<ApiChange>> _groupByChangeCategory(List<ApiChange> changes) {
+    return groupBy(
+      changes,
+      (change) =>
+          // calculate the "change category key" based on the change type, operation
+          // and, for constructor parameters, the constructor name
+          change.runtimeType.hashCode ^
+          change.operation.hashCode ^
+          (this is ConstructorParameterApiChange
+              ? (this as ConstructorParameterApiChange)
+                  .constructor
+                  .name
+                  .hashCode
+              : 0),
+    );
+  }
+
+  /// Format the result of the comparison
+  String _getHighestMagnitudeText(ApiChangeMagnitude highestMagnitude) {
+    switch (highestMagnitude) {
+      case ApiChangeMagnitude.major:
+        return "> 💣 **Breaking changes detected.** Bump the major version.";
+      case ApiChangeMagnitude.minor:
+        return '> ✨ **Minor changes detected.** Increment the minor version.';
+      case ApiChangeMagnitude.patch:
+        return '> 👀 **Internal changes detected.** Increment the patch version.';
+    }
+  }
+
+  /// Format a header for the magnitude section
+  String _getMagnitudeHeader(ApiChangeMagnitude magnitude) {
+    switch (magnitude) {
+      case ApiChangeMagnitude.major:
+        return '# 💣 Breaking changes (major increment)';
+      case ApiChangeMagnitude.minor:
+        return '# ✨ Minor changes, public (minor increment)';
+      case ApiChangeMagnitude.patch:
+        return '# 👀 Internal changes (patch increment)';
+    }
+  }
+
+  /// Get the text representation of an operation using a prefix (e.g.
+  /// "Properties", "Params", etc. depending on the type of change)
+  String _getOperationText(
+    ApiChangeOperation operation, {
+    required String prefix,
+  }) {
+    switch (operation) {
+      case ApiChangeOperation.added:
+        return '❇️ $prefix added';
+      case ApiChangeOperation.removed:
+        return '❌ $prefix removed';
+      case ApiChangeOperation.becameOptional:
+        return '✅ $prefix became optional';
+      case ApiChangeOperation.becameNullSafe:
+        return '✅ $prefix became null safe';
+      case ApiChangeOperation.becameRequired:
+        return '⚠️ $prefix became required';
+      case ApiChangeOperation.becameNullUnsafe:
+        return '⚠️ $prefix became null unsafe';
+      case ApiChangeOperation.becameNamed:
+        return '🔠 $prefix became named';
+      case ApiChangeOperation.becamePositional:
+        return '🔢 $prefix became positional';
+      default:
+        return '';
+    }
+  }
+
+  /// Format similar changes into a single line
+  String _formatChanges(List<ApiChange> changes) {
+    // we can rely that all changes are of the same operation
+    final operation = changes.first.operation;
+    if (changes.every((c) => c is PropertyApiChange)) {
+      final prefix = changes.length > 1 ? 'Properties' : 'Property';
+      final text = _getOperationText(operation, prefix: prefix);
+      final props =
+          changes.map((c) => (c as PropertyApiChange).property.name).toList();
+      return '$text: `${props.join('`, `')}`';
+    }
+
+    if (changes.every((c) => c is ConstructorParameterApiChange)) {
+      final prefix = changes.length > 1 ? 'Params' : 'Param';
+      final text = _getOperationText(operation, prefix: prefix);
+      final params = changes
+          .map((c) => (c as ConstructorParameterApiChange).parameter.name)
+          .toList();
+      final constructor =
+          (changes.first as ConstructorParameterApiChange).constructor.name;
+      final constructorLabel =
+          "${constructor.startsWith("_") ? "private " : ""}"
+          "constructor '${constructor.isEmpty ? 'default' : constructor}'";
+      return '$text in $constructorLabel: `${params.join('`, `')}`';
+    }
+
+    if (changes.every((c) => c is ConstructorApiChange)) {
+      // This should always be a single change, so we use singular:
+      final text = _getOperationText(operation, prefix: 'Constructor');
+      final constructors = changes
+          .map((c) => (c as ConstructorApiChange).constructor.name)
+          .toList();
+      return '$text: `${constructors.join('`, `')}`';
+    }
+
+    if (changes.every((c) => c is ComponentApiChange)) {
+      // This should always be a single change, so we use singular:
+      final text = _getOperationText(operation, prefix: 'Class');
+      final components =
+          changes.map((c) => (c as ComponentApiChange).component).toList();
+      return '$text: `${components.join('`, `')}`';
+    }
+
+    // This should actually never happen:
+    return '${changes.length} unknown changes';
+  }
+}

--- a/generators/lib/doc_comparator/doc_comparator.dart
+++ b/generators/lib/doc_comparator/doc_comparator.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:liquid_generators/doc_comparator/api_change.dart';
+import 'package:liquid_generators/doc_comparator/api_change_formatter.dart';
 import 'package:liquid_generators/doc_comparator/doc_ext.dart';
 import 'package:liquid_generators/doc_comparator/doc_parser.dart';
 
@@ -19,11 +20,19 @@ void main(List<String> args) async {
         'Example: dart doc_comparator.dart HEAD:./lib/documentation.dart origin/main:./lib/documentation.dart\n');
     print('Options:');
     print('  --help, -h: Show this help message');
-    print('  --verbose, -v: Print detailed information about the changes');
+    print('  --mag=<level>: Show only changes up to the specified magnitude');
+    print('    <level> can be one of: major, minor, patch, or none');
+    print('    Default is patch');
     return;
   }
 
-  final verbose = args.contains('--verbose') || args.contains('-v');
+  final magArg =
+      args.firstWhereOrNull((element) => element.startsWith('--mag='));
+  final mag = magArg?.split('=').last;
+  final magnitude = mag != null
+      ? ApiChangeMagnitude.values
+          .firstWhereOrNull((element) => element.toString().contains(mag))
+      : null;
 
   final positionalArgs =
       args.where((element) => !element.startsWith('-')).toList();
@@ -37,18 +46,7 @@ void main(List<String> args) async {
   final apiChanges = parseLdDocComponentsFile(baseContent).compareTo(
     parseLdDocComponentsFile(newContent),
   );
-
-  // print api changes
-  var result = ApiChangeType.patch;
-  for (var change in apiChanges) {
-    result = result.atLeast(change.type);
-    if (verbose) {
-      print(
-        "[${change.type.name}] change in '${change.component}': ${change.description}",
-      );
-    }
-  }
-  print(verbose ? '\nFinal result: ${result.name}' : result.name);
+  print(ApiChangeFormatter(apiChanges, showUpToMagnitude: magnitude).format());
 }
 
 Future<String> _getFileContent(String path) {

--- a/generators/lib/doc_comparator/doc_ext.dart
+++ b/generators/lib/doc_comparator/doc_ext.dart
@@ -2,25 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:liquid_generators/doc_comparator/api_change.dart';
 import 'package:liquid_generators/doc_items.dart';
 
-extension ParameterStringExt on Parameter {
-  String get nameString => "${required ? "required " : "optional "}"
-      "${named ? "named " : ""}"
-      "${name.startsWith('_') ? "private " : ""}"
-      "parameter '$name'";
-  String get typeString => "type '$type'";
-}
-
-extension PropertyStringExt on Property {
-  String get nameString => "${name.startsWith('_') ? "private " : ""}"
-      "property '$name'";
-  String get typeString => "type '$type'";
-}
-
-extension ConstructorStringExt on Constructor {
-  String get nameString => "${name.startsWith("_") ? "private " : ""}"
-      "constructor '${name.isEmpty ? 'default' : name}'";
-}
-
 extension DocComponentListApiChangesExt on List<DocComponent> {
   List<ApiChange> compareTo(List<DocComponent> newComponents) {
     final changes = <ApiChange>[];
@@ -29,10 +10,9 @@ extension DocComponentListApiChangesExt on List<DocComponent> {
       final newComponent = newComponents
           .firstWhereOrNull((element) => element.name == this[i].name);
       if (newComponent == null) {
-        changes.add(ApiChange(
+        changes.add(ComponentApiChange(
           component: this[i].name,
-          description: "${this[i].name} was removed",
-          type: ApiChangeType.major,
+          operation: ApiChangeOperation.removed,
         ));
         continue;
       }
@@ -43,10 +23,9 @@ extension DocComponentListApiChangesExt on List<DocComponent> {
       final oldComponent =
           firstWhereOrNull((element) => element.name == newComponents[i].name);
       if (oldComponent == null) {
-        changes.add(ApiChange(
+        changes.add(ComponentApiChange(
           component: newComponents[i].name,
-          description: "${newComponents[i].name} was added",
-          type: ApiChangeType.minor,
+          operation: ApiChangeOperation.added,
         ));
       }
     }
@@ -59,18 +38,15 @@ extension DocComponentApiChangesExt on DocComponent {
   List<ApiChange> compareTo(DocComponent newComponent) {
     final changes = <ApiChange>[];
 
-    /// For components starting with an underscore, we consider changes to be at
-    /// most minor, as they are private to the library and should not be used
-    /// outside of it.
-    final atMostChangeType =
-        name.startsWith('_') ? ApiChangeType.patch : ApiChangeType.major;
-
-    if (isNullSafe && !newComponent.isNullSafe) {
-      changes.add(ApiChange(
-        component: name,
-        description: "Component became null-unsafe",
-        type: ApiChangeType.major.atMost(atMostChangeType),
-      ));
+    if (isNullSafe != newComponent.isNullSafe) {
+      changes.add(
+        ComponentApiChange(
+          component: name,
+          operation: newComponent.isNullSafe
+              ? ApiChangeOperation.becameNullSafe
+              : ApiChangeOperation.becameNullUnsafe,
+        ),
+      );
     }
 
     changes.addAll(
@@ -92,56 +68,41 @@ extension ConstructorApiChangesExt on Constructor {
     required String componentName,
   }) {
     final changes = <ApiChange>[];
-    final atMostChangeType = componentName.startsWith('_')
-        ? ApiChangeType.patch
-        : ApiChangeType.major;
+    _addChange(Parameter parameter, ApiChangeOperation operation) {
+      changes.add(ConstructorParameterApiChange(
+        component: componentName,
+        constructor: this,
+        operation: operation,
+        parameter: parameter,
+      ));
+    }
 
     for (var i = 0; i < signature.length; i++) {
       final oldParam = signature[i];
       final newParam = newConstructor.signature
           .firstWhereOrNull((element) => element.name == oldParam.name);
       if (newParam == null) {
-        changes.add(ApiChange(
-          component: componentName,
-          description:
-              "${oldParam.nameString} was removed in ${newConstructor.nameString}",
-          type: ApiChangeType.major.atMost(atMostChangeType).atMost(
-                oldParam.required ? ApiChangeType.major : ApiChangeType.minor,
-              ),
-        ));
+        _addChange(oldParam, ApiChangeOperation.removed);
         continue;
       }
-      if (!oldParam.required && newParam.required) {
-        changes.add(ApiChange(
-          component: componentName,
-          description:
-              "${oldParam.nameString} became required in ${newConstructor.nameString}",
-          type: ApiChangeType.major.atMost(atMostChangeType),
-        ));
+      if (oldParam.required != newParam.required) {
+        _addChange(
+          oldParam,
+          oldParam.required
+              ? ApiChangeOperation.becameOptional
+              : ApiChangeOperation.becameRequired,
+        );
       }
       if (oldParam.named != newParam.named) {
-        changes.add(ApiChange(
-          component: componentName,
-          description:
-              "${oldParam.nameString} named changed from ${oldParam.named} to ${newParam.named} in ${newConstructor.nameString}",
-          type: ApiChangeType.major.atMost(atMostChangeType),
-        ));
+        _addChange(
+          oldParam,
+          oldParam.named
+              ? ApiChangeOperation.becamePositional
+              : ApiChangeOperation.becameNamed,
+        );
       }
       if (oldParam.type != newParam.type) {
-        changes.add(ApiChange(
-          component: componentName,
-          description:
-              "${oldParam.nameString} type changed from ${oldParam.typeString} to ${newParam.typeString} in ${newConstructor.nameString}",
-          type: ApiChangeType.major.atMost(atMostChangeType),
-        ));
-      }
-      if (oldParam.required && !newParam.required) {
-        changes.add(ApiChange(
-          component: componentName,
-          description:
-              "${oldParam.nameString} became optional in ${newConstructor.nameString}",
-          type: ApiChangeType.minor,
-        ));
+        _addChange(oldParam, ApiChangeOperation.typeChanged);
       }
     }
 
@@ -150,12 +111,7 @@ extension ConstructorApiChangesExt on Constructor {
       final oldParam = signature
           .firstWhereOrNull((element) => element.name == newParam.name);
       if (oldParam == null) {
-        changes.add(ApiChange(
-          component: componentName,
-          description:
-              "${newParam.nameString} was added in ${newConstructor.nameString}",
-          type: newParam.required ? ApiChangeType.major : ApiChangeType.minor,
-        ));
+        _addChange(newParam, ApiChangeOperation.added);
       }
     }
 
@@ -171,18 +127,15 @@ extension ConstructorListApiChangesExt on List<Constructor> {
     required String componentName,
   }) {
     final changes = <ApiChange>[];
-    final atMostChangeType = componentName.startsWith('_')
-        ? ApiChangeType.patch // changes to private comps are considered patch
-        : ApiChangeType.major;
 
     for (var i = 0; i < length; i++) {
       final newConstructor = newConstructors
           .firstWhereOrNull((element) => element.name == this[i].name);
       if (newConstructor == null) {
-        changes.add(ApiChange(
+        changes.add(ConstructorApiChange(
           component: componentName,
-          description: "${this[i].nameString} was removed from $componentName",
-          type: ApiChangeType.major.atMost(atMostChangeType),
+          constructor: this[i],
+          operation: ApiChangeOperation.removed,
         ));
         continue;
       }
@@ -194,11 +147,10 @@ extension ConstructorListApiChangesExt on List<Constructor> {
       final oldConstructor = firstWhereOrNull(
           (element) => element.name == newConstructors[i].name);
       if (oldConstructor == null) {
-        changes.add(ApiChange(
+        changes.add(ConstructorApiChange(
           component: componentName,
-          description:
-              "${newConstructors[i].nameString} was added to $componentName",
-          type: ApiChangeType.minor,
+          constructor: this[i],
+          operation: ApiChangeOperation.added,
         ));
       }
     }
@@ -215,30 +167,23 @@ extension PropertyListApiChangesExt on List<Property> {
     required String componentName,
   }) {
     final changes = <ApiChange>[];
-    final componentAtMostChangeType = componentName.startsWith('_')
-        ? ApiChangeType.patch // changes to private comps are considered patch
-        : ApiChangeType.major;
 
     for (var i = 0; i < length; i++) {
       final newProperty = newProperties
           .firstWhereOrNull((element) => element.name == this[i].name);
-      final propertyAtMostChangeType = this[i].name.startsWith('_')
-          ? ApiChangeType.patch // changes to private props are considered patch
-          : componentAtMostChangeType;
       if (newProperty == null) {
-        changes.add(ApiChange(
+        changes.add(PropertyApiChange(
           component: componentName,
-          description: "${this[i].nameString} was removed",
-          type: ApiChangeType.major.atMost(propertyAtMostChangeType),
+          property: this[i],
+          operation: ApiChangeOperation.removed,
         ));
         continue;
       }
       if (this[i].type != newProperty.type) {
-        changes.add(ApiChange(
+        changes.add(PropertyApiChange(
           component: componentName,
-          description:
-              "${this[i].nameString} type changed from ${this[i].typeString} to ${newProperty.typeString}",
-          type: ApiChangeType.major.atMost(propertyAtMostChangeType),
+          property: this[i],
+          operation: ApiChangeOperation.typeChanged,
         ));
       }
     }
@@ -247,12 +192,10 @@ extension PropertyListApiChangesExt on List<Property> {
       final oldProperty =
           firstWhereOrNull((element) => element.name == newProperties[i].name);
       if (oldProperty == null) {
-        changes.add(ApiChange(
+        changes.add(PropertyApiChange(
           component: componentName,
-          description: "${newProperties[i].nameString} was added",
-          type: ApiChangeType.minor.atMost(newProperties[i].name.startsWith('_')
-              ? ApiChangeType.patch // private new props are considered patch
-              : componentAtMostChangeType),
+          property: newProperties[i],
+          operation: ApiChangeOperation.added,
         ));
       }
     }

--- a/generators/lib/doc_items.dart
+++ b/generators/lib/doc_items.dart
@@ -36,9 +36,6 @@ class Property {
   String description;
 
   List<String> features;
-
-  String get nameString => "parameter '$name'";
-  String get typeString => "type '$type'";
 }
 
 class Constructor {
@@ -53,8 +50,6 @@ class Constructor {
   List<Parameter> signature;
 
   List<String> features;
-
-  String get nameString => "constructor '${name.isEmpty ? 'default' : name}'";
 }
 
 class Parameter {
@@ -75,7 +70,4 @@ class Parameter {
   bool named;
 
   bool required;
-
-  String get nameString => "parameter '$name'";
-  String get typeString => "type '$type'";
 }


### PR DESCRIPTION
- Update workflow to compare the actual (from the build_runner in the workflow) generated documentation.dart file with the documentation.dart file from origin/main.
- Enhance debug messages and fine-tune change detection (i.e., consider introducing or removing private properties/params as 'patch').