### PR TITLE
refactor(appbar): refactor LdAppBar to StatelessWidget, update API, and improve theme integration

### DIFF
--- a/example/lib/components/layout/appbar.dart
+++ b/example/lib/components/layout/appbar.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:liquid/components/component_page.dart';
+import 'package:liquid/components/component_well/component_well.dart';
+import 'package:liquid_flutter/liquid_flutter.dart';
+
+class AppBarDemo extends StatelessWidget {
+  const AppBarDemo({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ComponentPage(
+      title: "LdAppBar",
+      text: """
+`LdAppBar` is a cross-platform app bar widget that adapts its appearance to the Liquid Design system. It supports all standard AppBar features and is styled to match the current theme. Use it as a drop-in replacement for Flutter's AppBar for a consistent look and feel across your app.
+""",
+      demo: ComponentWell(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            LdAppBar(
+              title: const Text("Home"),
+            ),
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Text("This is a simple example of LdAppBar in use."),
+            ),
+          ],
+        ),
+      ),
+      apiComponents: ["LdAppBar"],
+    );
+  }
+}

--- a/example/lib/router.dart
+++ b/example/lib/router.dart
@@ -51,6 +51,7 @@ import 'components/form_elements/reactive_form.dart';
 import 'components/data_display/table.dart';
 import 'components/data_display/tag.dart';
 import 'window/app_scaffold.dart';
+import 'components/layout/appbar.dart';
 
 class AppRouter {
   AppRouter();
@@ -327,6 +328,11 @@ class AppRouter {
                 return NoTransitionPage<void>(
                     key: state.pageKey, child: const ReactiveFormDemo());
               }),
+          GoRoute(
+            path: "/components/appbar",
+            pageBuilder: (context, state) => NoTransitionPage<void>(
+                key: state.pageKey, child: const AppBarDemo()),
+          ),
         ]),
   ]);
 }

--- a/example/lib/window/app_scaffold.dart
+++ b/example/lib/window/app_scaffold.dart
@@ -44,9 +44,7 @@ class _AppScaffoldState extends State<AppScaffold> {
             child: Scaffold(
               drawer: !split ? const MainNavigationDrawer() : null,
               backgroundColor: themeService.background,
-              appBar: size.isMobile
-                  ? LdAppBar(context: context, title: widget.title)
-                  : null,
+              appBar: size.isMobile ? LdAppBar(title: widget.title) : null,
               body: LdNotificationPortal(
                 child: (split)
                     ? Stack(

--- a/example/lib/window/drawer.dart
+++ b/example/lib/window/drawer.dart
@@ -64,6 +64,8 @@ const components = [
       ComponentCategory.layout),
   _Component("Selectable List", "/components/selectable-list",
       LucideIcons.listCheck, ComponentCategory.layout),
+  _Component("AppBar", "/components/appbar", LucideIcons.layoutPanelTop,
+      ComponentCategory.layout),
 
   // Form Elements
   _Component("Checkbox", "/components/checkbox", LucideIcons.circleCheck,
@@ -238,13 +240,13 @@ class _MainNavigationDrawerState extends State<MainNavigationDrawer> {
       elevation: 0,
       shape: const RoundedRectangleBorder(),
       backgroundColor: theme.surface,
-      child: SafeArea(
-        child: Container(
-          decoration: BoxDecoration(
-            border: Border(
-              right: BorderSide(color: theme.border, width: 1),
-            ),
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            right: BorderSide(color: theme.border, width: 1),
           ),
+        ),
+        child: SafeArea(
           child: CustomScrollView(
             controller: _scrollController,
             slivers: [

--- a/lib/src/appbar.dart
+++ b/lib/src/appbar.dart
@@ -1,60 +1,144 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
 
-class LdAppBar extends AppBar {
-  LdAppBar({
+class LdAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final Widget? title;
+  final List<Widget>? actions;
+  final Widget? leading;
+  final double? elevation;
+  final IconThemeData? iconTheme;
+  final bool? primary;
+  final bool? centerTitle;
+  final double? titleSpacing;
+  final double? toolbarOpacity;
+  final double? bottomOpacity;
+  final double? toolbarHeight;
+  final TextStyle? titleTextStyle;
+  final Color? backgroundColor;
+  final IconThemeData? actionsIconTheme;
+  final Widget? flexibleSpace;
+  final Color? foregroundColor;
+  final bool? automaticallyImplyLeading;
+  final Clip? clipBehavior;
+  final ShapeBorder? shape;
+  final TextStyle? toolbarTextStyle;
+  final double? leadingWidth;
+  final ScrollNotificationPredicate? notificationPredicate;
+  final bool? forceMaterialTransparency;
+  final double? scrolledUnderElevation;
+  final Color? surfaceTintColor;
+  final bool? excludeHeaderSemantics;
+  final BuildContext? context;
+
+  const LdAppBar({
     super.key,
-    required BuildContext context,
-    Widget? title,
-    super.actions,
-    super.leading,
-    super.elevation,
-    super.iconTheme,
-    super.primary,
-    super.centerTitle,
-    super.titleSpacing,
-    super.toolbarOpacity,
-    super.bottomOpacity,
-    double? toolbarHeight,
-    super.titleTextStyle,
-    super.backgroundColor,
-    super.actionsIconTheme,
-    super.flexibleSpace,
-    super.foregroundColor,
-    super.automaticallyImplyLeading,
-    super.clipBehavior,
-    super.shape,
-    super.toolbarTextStyle,
-    super.leadingWidth,
-    super.notificationPredicate,
-    super.forceMaterialTransparency,
-    super.scrolledUnderElevation,
-    super.surfaceTintColor,
-    super.excludeHeaderSemantics,
-  }) : super(
-          shadowColor: LdTheme.of(context, listen: true).neutralShade(1),
+    @Deprecated(
+      "Context is no longer needed you can simply remove this parameter",
+    )
+    this.context,
+    this.title,
+    this.actions,
+    this.leading,
+    this.elevation,
+    this.iconTheme,
+    this.primary,
+    this.centerTitle,
+    this.titleSpacing,
+    this.toolbarOpacity,
+    this.bottomOpacity,
+    this.toolbarHeight,
+    this.titleTextStyle,
+    this.backgroundColor,
+    this.actionsIconTheme,
+    this.flexibleSpace,
+    this.foregroundColor,
+    this.automaticallyImplyLeading,
+    this.clipBehavior,
+    this.shape,
+    this.toolbarTextStyle,
+    this.leadingWidth,
+    this.notificationPredicate,
+    this.forceMaterialTransparency,
+    this.scrolledUnderElevation,
+    this.surfaceTintColor,
+    this.excludeHeaderSemantics,
+  });
+
+  @override
+  Size get preferredSize {
+    if (toolbarHeight != null) {
+      return Size.fromHeight(toolbarHeight! + 1);
+    }
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.macOS:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return const Size.fromHeight(kToolbarHeight + 1);
+      default:
+        return const Size.fromHeight(kToolbarHeight + 1);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = LdTheme.of(context, listen: true);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppBar(
+          key: key,
+          actions: actions,
+          leading: leading,
+          elevation: elevation,
+          iconTheme: iconTheme,
+          primary: primary ?? true,
+          centerTitle: centerTitle,
+          titleSpacing: titleSpacing,
+          toolbarOpacity: toolbarOpacity ?? 1.0,
+          bottomOpacity: bottomOpacity ?? 1.0,
+          toolbarHeight: toolbarHeight ??
+              (theme.themeSize == LdThemeSize.s ? 48 : kToolbarHeight),
+          titleTextStyle: titleTextStyle,
+          backgroundColor: backgroundColor,
+          actionsIconTheme: actionsIconTheme,
+          flexibleSpace: flexibleSpace,
+          foregroundColor: foregroundColor,
+          automaticallyImplyLeading: automaticallyImplyLeading ?? true,
+          clipBehavior: clipBehavior ?? Clip.none,
+          shape: shape,
+          toolbarTextStyle: toolbarTextStyle,
+          leadingWidth: leadingWidth,
+          notificationPredicate: notificationPredicate ??
+              (notification) => notification.depth == 0,
+          forceMaterialTransparency: forceMaterialTransparency ?? false,
+          scrolledUnderElevation: scrolledUnderElevation,
+          surfaceTintColor: surfaceTintColor,
+          excludeHeaderSemantics: excludeHeaderSemantics ?? false,
+          shadowColor: theme.neutralShade(1),
           systemOverlayStyle: SystemUiOverlayStyle(
-            statusBarColor: LdTheme.of(context).surface,
-            systemNavigationBarColor: LdTheme.of(context).surface,
-            systemNavigationBarIconBrightness: LdTheme.of(context).isDark ? Brightness.light : Brightness.dark,
-            statusBarIconBrightness: LdTheme.of(context).isDark ? Brightness.light : Brightness.dark,
-            statusBarBrightness: LdTheme.of(context).isDark ? Brightness.dark : Brightness.light,
+            statusBarColor: theme.surface,
+            systemNavigationBarColor: theme.surface,
+            systemNavigationBarIconBrightness:
+                theme.isDark ? Brightness.light : Brightness.dark,
+            statusBarIconBrightness:
+                theme.isDark ? Brightness.light : Brightness.dark,
+            statusBarBrightness:
+                theme.isDark ? Brightness.dark : Brightness.light,
           ),
           title: DefaultTextStyle(
             style: ldBuildTextStyle(
-              LdTheme.of(context),
+              theme,
               LdTextType.headline,
               LdSize.s,
             ),
             child: title ?? const SizedBox(),
           ),
-          toolbarHeight: toolbarHeight ?? (LdTheme.of(context).themeSize == LdThemeSize.s ? 48 : kToolbarHeight),
-          bottom: const PreferredSize(
-            preferredSize: Size.fromHeight(1),
-            child: LdDivider(
-              height: 1,
-            ),
-          ),
-        );
+        ),
+        const LdDivider(height: 1),
+      ],
+    );
+  }
 }

--- a/lib/src/choose.dart
+++ b/lib/src/choose.dart
@@ -278,7 +278,6 @@ class _LdChoosePage<T> extends StatelessWidget {
     var theme = LdTheme.of(context, listen: true);
     return Scaffold(
       appBar: LdAppBar(
-        context: context,
         title: Text(label),
       ),
       backgroundColor: theme.background,

--- a/lib/src/context_menu.dart
+++ b/lib/src/context_menu.dart
@@ -157,8 +157,8 @@ class _LdContextMenuState extends State<LdContextMenu> {
     final screenSize = mediaQuery.size;
 
     return Offset(
-      position.dx.clamp(0, screenSize.width - inset.right - inset.left - 10),
-      position.dy.clamp(0, screenSize.height - inset.bottom - inset.top - 10),
+      position.dx.clamp(10, screenSize.width - inset.right - inset.left - 10),
+      position.dy.clamp(10, screenSize.height - inset.bottom - inset.top - 10),
     );
   }
 

--- a/lib/src/master_detail.dart
+++ b/lib/src/master_detail.dart
@@ -284,7 +284,6 @@ class _LdMasterDetailState<T> extends State<LdMasterDetail<T>>
     return Scaffold(
       appBar: LdAppBar(
         scrolledUnderElevation: isSeparatePage ? 4 : 0,
-        context: context,
         title: widget.builder.buildMasterTitle(
           context,
           _onSelect,
@@ -318,7 +317,6 @@ class _LdMasterDetailState<T> extends State<LdMasterDetail<T>>
       appBar: LdAppBar(
         automaticallyImplyLeading: false,
         scrolledUnderElevation: isSeparatePage ? 4 : 0,
-        context: context,
         title: widget.builder.buildDetailTitle(
           context,
           item,
@@ -441,7 +439,6 @@ class _DetailPage<T> extends StatelessWidget {
       child: Scaffold(
         backgroundColor: LdTheme.of(context).background,
         appBar: LdAppBar(
-          context: context,
           title: builder.buildDetailTitle(context, item, true, deselect),
           actions: builder.buildDetailActions(context, item, true, deselect),
         ),

--- a/lib/src/submit/model/submit_controller.dart
+++ b/lib/src/submit/model/submit_controller.dart
@@ -95,6 +95,7 @@ class LdSubmitController<T> {
       } else {
         res = await config.action();
       }
+
       if (!_isLoading) return;
 
       _retryController.notifyOperationCompleted();
@@ -110,7 +111,9 @@ class LdSubmitController<T> {
       final exception = exceptionMapper.handle(e, stackTrace: s);
 
       if (ldPrintDebugMessages) {
-        debugPrint("An error occurred in LdSubmitController: $e \n $s");
+        debugPrint(
+          "An error occurred in LdSubmitController<${T.toString()}>: $e \n $s",
+        );
       }
 
       _setState(

--- a/lib/src/theme/liquid_material_theme.dart
+++ b/lib/src/theme/liquid_material_theme.dart
@@ -55,7 +55,6 @@ ThemeData getMaterialTheme(LdTheme theme) {
       appBarTheme: AppBarTheme(
         backgroundColor: theme.surface,
         surfaceTintColor: theme.surface,
-        centerTitle: false,
         foregroundColor: theme.text,
         shadowColor: theme.neutralShade(2),
       ),


### PR DESCRIPTION
## Refactor LdAppBar

- Refactored `LdAppBar` to extend `StatelessWidget` instead of `AppBar`.
- Updated the API to remove the need for a `context` parameter.
- Improved theme integration and made the component more flexible.
- Updated usages and documentation accordingly.
- Added a new example for `LdAppBar` usage.

The `context` parameter is no longer required for `LdAppBar`. Please update usages accordingly.

