### PR TITLE
fix(LdRepository): restore filtered items when optimistic filters broaden

### DIFF
--- a/packages/liquid_flutter/lib/src/list/list_paginator.dart
+++ b/packages/liquid_flutter/lib/src/list/list_paginator.dart
@@ -267,7 +267,7 @@ class LdPaginator<T extends Identifiable<IdType>, IdType> extends ChangeNotifier
   // Refresh List - clear and fetch initial data
   Future<void> refreshList() async {
     for (final item in _items.entries) {
-      if (item.value.value != null) {
+      if (item.value.value != null && item.value.state != LdPaginatorItemState.filteredOut) {
         _items[item.key] = item.value.copyWith(state: LdPaginatorItemState.pendingRefresh);
       }
     }

--- a/packages/liquid_flutter/lib/src/monkey/data/repository.dart
+++ b/packages/liquid_flutter/lib/src/monkey/data/repository.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:liquid_flutter/liquid_flutter.dart';
-
 import 'package:provider/provider.dart';
 
 typedef FetchListWithParameters<T extends Identifiable<IdType>, IdType> = Future<LdListPage<T>> Function({

--- a/packages/liquid_flutter/lib/src/monkey/data/repository.dart
+++ b/packages/liquid_flutter/lib/src/monkey/data/repository.dart
@@ -204,8 +204,13 @@ class LdRepository<T extends Identifiable<IdType>, IdType> extends LdPaginator<T
         }
       }
 
-      totalItems = updatedItems.length;
-      setItems(updatedItems);
+      final visibleItems = updatedItems.where((item) => item.state != LdPaginatorItemState.filteredOut).toList();
+      final filteredOutItems = updatedItems.where((item) => item.state == LdPaginatorItemState.filteredOut).toList();
+
+      // Keep filtered-out items in-memory for quick restore when filters broaden,
+      // but only expose visible items through [0..totalItems) for list rendering.
+      totalItems = visibleItems.length;
+      setItems([...visibleItems, ...filteredOutItems]);
     } finally {
       mutex.release();
     }

--- a/packages/liquid_flutter/lib/src/monkey/data/repository.dart
+++ b/packages/liquid_flutter/lib/src/monkey/data/repository.dart
@@ -30,6 +30,7 @@ class LdRepository<T extends Identifiable<IdType>, IdType> extends LdPaginator<T
 
   final Map<String, LdFilterOption<T, IdType>> _filters;
   final List<LdSortOption<T, IdType>> _sortOptions;
+  final Map<IdType, LdPaginatorItem<T>> _filteredOutCache = {};
 
   Map<String, LdFilterOption<T, IdType>> get filters => Map.unmodifiable(_filters);
   List<LdSortOption<T, IdType>> get sortOptions => List.unmodifiable(_sortOptions);
@@ -182,18 +183,32 @@ class LdRepository<T extends Identifiable<IdType>, IdType> extends LdPaginator<T
 
     await mutex.acquire();
     try {
-      final updatedItems = itemsMap.entries.where((item) => item.value.value != null).map((item) {
-        final filterApplies = filters.every((filter) => filter.optimisticFilter(item.value.value!));
+      final allItemsById = <IdType, LdPaginatorItem<T>>{};
 
-        var newState = item.value.state;
+      for (final cached in _filteredOutCache.values) {
+        if (cached.value != null) {
+          allItemsById[cached.value!.id] = cached;
+        }
+      }
+
+      for (final item in itemsMap.values) {
+        if (item.value != null) {
+          allItemsById[item.value!.id] = item;
+        }
+      }
+
+      final updatedItems = allItemsById.values.map((item) {
+        final filterApplies = filters.every((filter) => filter.optimisticFilter(item.value!));
+
+        var newState = item.state;
 
         if (!filterApplies) {
           newState = LdPaginatorItemState.filteredOut;
-        } else if (item.value.state == LdPaginatorItemState.filteredOut) {
+        } else if (item.state == LdPaginatorItemState.filteredOut) {
           newState = LdPaginatorItemState.loaded;
         }
 
-        return item.value.copyWith(
+        return item.copyWith(
           state: newState,
         );
       }).toList();
@@ -207,10 +222,14 @@ class LdRepository<T extends Identifiable<IdType>, IdType> extends LdPaginator<T
       final visibleItems = updatedItems.where((item) => item.state != LdPaginatorItemState.filteredOut).toList();
       final filteredOutItems = updatedItems.where((item) => item.state == LdPaginatorItemState.filteredOut).toList();
 
-      // Keep filtered-out items in-memory for quick restore when filters broaden,
-      // but only expose visible items through [0..totalItems) for list rendering.
+      _filteredOutCache
+        ..clear()
+        ..addEntries(filteredOutItems.map((item) => MapEntry(item.value!.id, item)));
+
+      // Keep filtered-out items in a dedicated cache for quick restore when
+      // filters broaden, while exposing only visible items in paginator indices.
       totalItems = visibleItems.length;
-      setItems([...visibleItems, ...filteredOutItems]);
+      setItems(visibleItems);
     } finally {
       mutex.release();
     }
@@ -390,6 +409,7 @@ class LdRepository<T extends Identifiable<IdType>, IdType> extends LdPaginator<T
 
   @override
   void dispose() {
+    _filteredOutCache.clear();
     _filterStreamController.close();
     _sortStreamController.close();
     super.dispose();

--- a/packages/liquid_flutter/lib/src/monkey/data/repository.dart
+++ b/packages/liquid_flutter/lib/src/monkey/data/repository.dart
@@ -182,43 +182,34 @@ class LdRepository<T extends Identifiable<IdType>, IdType> extends LdPaginator<T
     final sortOptions = _sortOptions.where((e) => e.isOn).toList();
 
     await mutex.acquire();
-    var filteredItems = Map.fromEntries(
-      itemsMap.entries.where((item) => item.value.value != null).map((item) {
+    try {
+      final updatedItems = itemsMap.entries.where((item) => item.value.value != null).map((item) {
         final filterApplies = filters.every((filter) => filter.optimisticFilter(item.value.value!));
 
-        var newState = filterApplies ? item.value.state : LdPaginatorItemState.filteredOut;
+        var newState = item.value.state;
 
-        if (newState == LdPaginatorItemState.filteredOut && filterApplies) {
+        if (!filterApplies) {
+          newState = LdPaginatorItemState.filteredOut;
+        } else if (item.value.state == LdPaginatorItemState.filteredOut) {
           newState = LdPaginatorItemState.loaded;
         }
 
-        return MapEntry(
-          item.key,
-          item.value.copyWith(
-            state: newState,
-          ),
+        return item.value.copyWith(
+          state: newState,
         );
-      }),
-    );
+      }).toList();
 
-    replaceItems(filteredItems);
-
-    filteredItems.removeWhere((key, value) => value.state == LdPaginatorItemState.filteredOut || value.value == null);
-
-    final sortedItems = filteredItems.values.toList();
-
-    totalItems = filteredItems.length;
-
-    for (final sortOption in sortOptions) {
-      if (sortOption.optimisticSort != null) {
-        sortedItems.sort((a, b) => sortOption.optimisticSort!(a.value!, b.value!));
+      for (final sortOption in sortOptions) {
+        if (sortOption.optimisticSort != null) {
+          updatedItems.sort((a, b) => sortOption.optimisticSort!(a.value!, b.value!));
+        }
       }
+
+      totalItems = updatedItems.length;
+      setItems(updatedItems);
+    } finally {
+      mutex.release();
     }
-
-    // Apply the sorting to the previous list
-
-    setItems(sortedItems);
-    mutex.release();
   }
 
   Iterable<LdFilterOption<T, IdType>> get activeFilters => _filters.values.where((e) => e.isOn);

--- a/packages/liquid_flutter/test/repository_test.dart
+++ b/packages/liquid_flutter/test/repository_test.dart
@@ -733,6 +733,17 @@ void main() {
         // After narrowing, only ids 2 and 3 should still be visible.
         expect(narrowedVisibleIds, equals({2, 3}));
 
+        // While the filter is still narrowed, a refresh should not resurrect
+        // filtered-out items into the visible range.
+        await repository.refreshList();
+
+        final afterRefreshVisibleIds = repository.itemsMap.values
+            .where((item) => item.value != null && item.state != LdPaginatorItemState.filteredOut)
+            .map((item) => item.value!.id)
+            .toSet();
+
+        expect(afterRefreshVisibleIds, equals({2, 3}));
+
         // BROADENING phase (regression coverage):
         // broaden the same active filter again and verify previously filtered-out
         // items are restored without disabling/removing the filter.

--- a/packages/liquid_flutter/test/repository_test.dart
+++ b/packages/liquid_flutter/test/repository_test.dart
@@ -678,12 +678,15 @@ void main() {
       });
 
       test('applyOptimisticFilterAndSorting filters items correctly', () async {
-        final filter = _MockFilterOption<_TestItem, int>(
-          name: 'valueFilter',
-          label: (context) => 'Value Filter',
+        final filter = LdFilterRange<_TestItem, int>(
+          name: 'valueRange',
+          label: (context) => 'Value Range',
           icon: (context) => const Icon(Icons.filter_list),
-          optimisticFilterFunc: (item) => item.value > 15,
+          min: 0,
+          max: 100,
+          range: const RangeValues(0, 100),
           isOn: true,
+          optimisticFilter: (item, range) => item.value >= range.start && item.value <= range.end,
         );
 
         final items = [
@@ -715,17 +718,36 @@ void main() {
         });
         repository.totalItems = 3;
 
-        await repository.updateFilter('valueFilter', (f) => f!.copyWith(isOn: true));
-        await Future.delayed(const Duration(milliseconds: 600)); // Wait for optimistic filtering delay
+        // NARROWING phase:
+        // tighten the active range filter so only items in [20, 30] remain visible.
+        await repository.updateFilter(
+          'valueRange',
+          (f) => (f as LdFilterRange<_TestItem, int>).copyWith(range: const RangeValues(20, 30), isOn: true),
+        );
 
-        final filteredItems = repository.itemsMap.values
-            .where((item) => item.state != LdPaginatorItemState.filteredOut)
-            .map((item) => item.value)
-            .whereType<_TestItem>()
-            .toList();
+        final narrowedVisibleIds = repository.itemsMap.values
+            .where((item) => item.value != null && item.state != LdPaginatorItemState.filteredOut)
+            .map((item) => item.value!.id)
+            .toSet();
 
-        expect(filteredItems.length, greaterThan(0));
-        expect(filteredItems.every((item) => item.value > 15), isTrue);
+        // After narrowing, only ids 2 and 3 should still be visible.
+        expect(narrowedVisibleIds, equals({2, 3}));
+
+        // BROADENING phase (regression coverage):
+        // broaden the same active filter again and verify previously filtered-out
+        // items are restored without disabling/removing the filter.
+        await repository.updateFilter(
+          'valueRange',
+          (f) => (f as LdFilterRange<_TestItem, int>).copyWith(range: const RangeValues(0, 30), isOn: true),
+        );
+
+        final broadenedVisibleIds = repository.itemsMap.values
+            .where((item) => item.value != null && item.state != LdPaginatorItemState.filteredOut)
+            .map((item) => item.value!.id)
+            .toSet();
+
+        // Item 1 must reappear here. This is the bug we are guarding against.
+        expect(broadenedVisibleIds, equals({1, 2, 3}));
       });
     });
 


### PR DESCRIPTION
This fixes an issue in optimistic filtering where filtering only worked in one direction.

### Problem
When a filter became stricter, non-matching items were correctly hidden.  
But when the filter was broadened again, those items often didn’t come back right away. In practice, users had to fully clear the filter or refresh to see them again.

![Screen Recording 2026-02-12 at 15 59 03](https://github.com/user-attachments/assets/6d0702d3-106e-4e8b-a2f5-6adf6aecc5b7)

### Root cause
The optimistic filter/sort pass in `repository.dart` wasn’t consistently rebuilding item visibility from the current in-memory paginator state.  
Items that had already moved to `filteredOut` could stay stuck there.

### What changed
- Updated `applyOptimisticFilterAndSorting()` to recompute filter state for all loaded items on each change.
- Restores items from `LdPaginatorItemState.filteredOut` to `LdPaginatorItemState.loaded` as soon as they match again.
- Applies sorting after state recalculation so order remains stable and predictable.
- Added safer mutex handling (`try/finally`) around the update path.

### Result
Optimistic filtering now behaves correctly in both directions:
- tighten filter → items are hidden
- broaden filter → matching items immediately reappear

No public API changes.