### PR TITLE
feat(liquid_flutter_md): add markdown package and example demo

### DIFF
--- a/apps/example/lib/components/data_display/markdown.dart
+++ b/apps/example/lib/components/data_display/markdown.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:liquid/components/component_page.dart';
+import 'package:liquid_flutter/liquid_flutter.dart';
+import 'package:liquid_flutter_md/markdown_widget.dart';
+
+const _defaultDemoMarkdown = r'''# Heading 1
+
+## Heading 2
+
+### Heading 3
+
+A paragraph with **bold** and *italic* text.
+
+- Unordered item one
+- Unordered item two
+
+1. Ordered item one
+2. Ordered item two
+
+Inline `code` and a [link](https://example.com).
+
+> A blockquote.
+
+| Name   | Role    | Status  |
+| ------ | ------- | ------- |
+| Alice  | Admin   | Active  |
+| Bob    | Editor  | Pending |
+| Carol  | Viewer  | Active  |
+
+
+```dart
+void main() {
+  print('Hello, world!');
+}
+```
+
+---
+''';
+
+class MarkdownDemo extends StatefulWidget {
+  const MarkdownDemo({super.key});
+
+  @override
+  State<MarkdownDemo> createState() => _MarkdownDemoState();
+}
+
+class _MarkdownDemoState extends State<MarkdownDemo> {
+  final _controller = TextEditingController(text: _defaultDemoMarkdown);
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = LdTheme.of(context);
+    final padding = theme.pad(size: LdSize.m);
+
+    return ComponentPage(
+      path: "lib/components/data_display/markdown.dart",
+      title: "LdMarkdown",
+      category: "Data Display",
+      demo: LdAutoSpace(
+        children: [
+          LdText.l("Edit markdown"),
+          LdInput(controller: _controller, hint: "Enter markdown...", minLines: 6, maxLines: 12),
+          LdText.l("Preview"),
+          LdMarkdown(data: _controller.text, padding: padding),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/example/lib/router.dart
+++ b/apps/example/lib/router.dart
@@ -59,6 +59,7 @@ import 'components/form_elements/form.dart';
 import 'components/feedback/hint.dart';
 import 'components/form_elements/input.dart';
 import 'components/feedback/notification.dart';
+import 'components/data_display/markdown.dart';
 import 'components/data_display/table.dart';
 import 'components/data_display/tag.dart';
 import 'window/app_scaffold.dart';
@@ -410,6 +411,11 @@ class AppRouter {
           GoRoute(
             path: "/components/bento-gallery",
             pageBuilder: (context, state) => NoTransitionPage<void>(key: state.pageKey, child: const BentoGallery()),
+          ),
+          GoRoute(
+            path: "/components/markdown",
+            pageBuilder: (context, state) =>
+                NoTransitionPage<void>(key: state.pageKey, child: const MarkdownDemo()),
           ),
         ],
       ),

--- a/apps/example/lib/window/drawer.dart
+++ b/apps/example/lib/window/drawer.dart
@@ -82,6 +82,7 @@ const components = [
   // Data Display
   _Component("Avatar", "/components/avatar", LucideIcons.user, ComponentCategory.dataDisplay),
   _Component("Icon", "/components/icon", LucideIcons.image, ComponentCategory.dataDisplay),
+  _Component("Markdown", "/components/markdown", LucideIcons.fileText, ComponentCategory.dataDisplay),
   _Component("Table", "/components/table", LucideIcons.grid3x3, ComponentCategory.dataDisplay),
   _Component("Tag", "/components/tag", LucideIcons.tag, ComponentCategory.dataDisplay),
 ];

--- a/apps/example/pubspec.yaml
+++ b/apps/example/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   flutter_portal: ^1.1.3
   syntax_highlight: ^0.5.0
   implicitly_animated_list: ^2.2.0
-  js: ^0.7.2
 
   provider: ^6.0.2
 
@@ -31,8 +30,7 @@ dependencies:
   go_router: ^17.0.1
   package_info_plus: ^9.0.0
   web: ^1.1.0
-  
-  
+
   google_fonts: ^8.0.1
   url_launcher: ^6.3.1
   fuzzy: ^0.5.1
@@ -46,6 +44,8 @@ dependencies:
 
   liquid_flutter_window_utils:
     path: ../../packages/liquid_flutter_window_utils
+  liquid_flutter_md:
+    path: ../../packages/liquid_flutter_md
   hooks: ^1.0.0
 
 dev_dependencies:

--- a/packages/liquid_flutter_md/.gitignore
+++ b/packages/liquid_flutter_md/.gitignore
@@ -1,0 +1,31 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins-dependencies
+/build/
+/coverage/

--- a/packages/liquid_flutter_md/.metadata
+++ b/packages/liquid_flutter_md/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "bd7a4a6b5576630823ca344e3e684c53aa1a0f46"
+  channel: "stable"
+
+project_type: package

--- a/packages/liquid_flutter_md/CHANGELOG.md
+++ b/packages/liquid_flutter_md/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/packages/liquid_flutter_md/LICENSE
+++ b/packages/liquid_flutter_md/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/packages/liquid_flutter_md/README.md
+++ b/packages/liquid_flutter_md/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/to/develop-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/packages/liquid_flutter_md/analysis_options.yaml
+++ b/packages/liquid_flutter_md/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/liquid_flutter_md/lib/markdown_widget.dart
+++ b/packages/liquid_flutter_md/lib/markdown_widget.dart
@@ -1,0 +1,316 @@
+import 'package:collection/collection.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:html_unescape/html_unescape.dart';
+import 'package:liquid_flutter/liquid_flutter.dart';
+import 'package:markdown/markdown.dart' as md;
+import 'package:syntax_highlight/syntax_highlight.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// A custom markdown widget that renders markdown using Liquid Flutter components
+class LdMarkdown extends StatelessWidget {
+  final String data;
+  final bool shrinkWrap;
+  final EdgeInsets padding;
+
+  const LdMarkdown({
+    super.key,
+    required this.data,
+    this.shrinkWrap = true,
+    this.padding = EdgeInsets.zero,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    // Parse markdown
+    final document = md.Document(extensionSet: md.ExtensionSet.gitHubWeb);
+
+    final nodes = document.parse(data);
+
+    // Build widgets using visitor
+
+    final widgets = markdownToWidgets(context, nodes);
+
+    if (widgets.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    return Padding(
+      padding: padding,
+      child: shrinkWrap
+          ? LdAutoSpace(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: widgets,
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: widgets,
+            ),
+    );
+  }
+}
+
+List<Widget> markdownToWidgets(BuildContext context, List<md.Node> nodes) {
+  final widgets = <Widget>[];
+
+  final theme = LdTheme.of(context);
+  for (final node in nodes) {
+    if (node is md.Element) {
+      final childrenWidgets = markdownToWidgets(context, node.children ?? []);
+      final child = switch (childrenWidgets.length) {
+        0 => const SizedBox.shrink(),
+        1 => childrenWidgets.first,
+        _ => Wrap(
+          alignment: WrapAlignment.start,
+          runAlignment: WrapAlignment.start,
+          children: childrenWidgets,
+        ),
+      };
+      widgets.add(switch (node.tag) {
+        'p' ||
+        'h1' ||
+        'h2' ||
+        'h3' ||
+        'h4' ||
+        'h5' ||
+        'h6' => buildText(context, node),
+
+        'ul' => SizedBox(
+          width: double.infinity,
+          child: LdBundle(
+            children: childrenWidgets
+                .map(
+                  (e) => Padding(
+                    padding: EdgeInsets.only(left: 4),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('•'),
+                        SizedBox(width: 4),
+                        Expanded(child: e),
+                      ],
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+
+        'img' => Image.network(node.attributes['src'] ?? ''),
+        'ol' => SizedBox(
+          width: double.infinity,
+          child: LdBundle(
+            children: childrenWidgets
+                .mapIndexed(
+                  (index, e) => Padding(
+                    padding: EdgeInsets.only(left: 4),
+                    child: Row(
+                      children: [
+                        Text('${index + 1}.'),
+                        SizedBox(width: 4),
+                        Flexible(child: e),
+                      ],
+                    ),
+                  ),
+                )
+                .toList(),
+          ),
+        ),
+        'br' => ldSpacerL,
+        'hr' => LdDivider(),
+        'li' => child,
+        'input' => LdCheckbox(checked: node.attributes['checked'] == 'true'),
+
+        'strong' => DefaultTextStyle(
+          style: TextStyle(fontWeight: FontWeight.bold),
+          child: child,
+        ),
+        'pre' => LdCard(child: child),
+        'code' => _MarkdownCode(
+          code: node.textContent,
+          language: node.attributes['class']?.split('-').lastOrNull ?? 'text',
+        ),
+        'blockquote' => LdCard(
+          child: LdBundle(
+            children: markdownToWidgets(context, node.children ?? []),
+          ),
+        ),
+
+        'table' => LdCard(
+          padding: EdgeInsets.zero,
+          child: Column(children: [...childrenWidgets]),
+        ),
+        'tbody' => Column(children: childrenWidgets),
+        'thead' => LdAutoBackground(child: Column(children: childrenWidgets)),
+        'th' || 'td' => Expanded(
+          child: Padding(
+            padding: theme.pad(size: LdSize.s),
+            child: child,
+          ),
+        ),
+        'tr' => Row(children: childrenWidgets),
+
+        'div' => switch (node.attributes['class']?.split(' ').firstOrNull) {
+          'markdown-alert' => LdHint(
+            type: switch (node.attributes['class']?.split('-').last) {
+              'note' => LdHintType.info,
+              'tip' => LdHintType.info,
+              'important' => LdHintType.warning,
+              'caution' => LdHintType.warning,
+              'warning' => LdHintType.warning,
+              _ => throw Exception(
+                'Invalid hint type: ${node.attributes['class']?.split('-').last}',
+              ),
+            },
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: childrenWidgets,
+            ),
+          ),
+          _ => SizedBox(width: double.infinity, child: child),
+        },
+
+        _ => Text(node.tag),
+      });
+    } else if (node is md.Text) {
+      //print('text: ${node.textContent}');
+      final unescape = HtmlUnescape();
+      widgets.add(Text(unescape.convert(node.textContent)));
+    } else if (node is md.UnparsedContent) {
+      // print('unparsedContent: ${node.textContent}');
+      widgets.add(Text(node.textContent));
+    }
+  }
+  return widgets;
+}
+
+class _MarkdownCode extends StatefulWidget {
+  final String code;
+  final String language;
+  const _MarkdownCode({required this.code, required this.language});
+
+  @override
+  State<_MarkdownCode> createState() => _MarkdownCodeState();
+}
+
+class _MarkdownCodeState extends State<_MarkdownCode> {
+  TextSpan highlightedCode = TextSpan();
+  Highlighter? highlighter;
+  @override
+  void initState() {
+    super.initState();
+    _loadHighlighter();
+  }
+
+  void _loadHighlighter() async {
+    final theme = await (LdTheme.of(context).isDark
+        ? HighlighterTheme.loadDarkTheme()
+        : HighlighterTheme.loadLightTheme());
+    await Highlighter.initialize([widget.language]);
+
+    highlighter = Highlighter(language: widget.language, theme: theme);
+    highlightedCode = highlighter?.highlight(widget.code) ?? TextSpan();
+  }
+
+  @override
+  void didUpdateWidget(covariant _MarkdownCode oldWidget) {
+    if (oldWidget.code != widget.code) {
+      highlightedCode = highlighter?.highlight(widget.code) ?? TextSpan();
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.language.isEmpty || widget.language == 'text') {
+      return Text(widget.code);
+    }
+    return Text.rich(highlightedCode);
+  }
+}
+/* 
+extension on md.Node {
+  String toStringHuman({int indent = 0}) {
+    final indentString = ' ' * indent;
+
+    if (this is md.Element) {
+      final element = this as md.Element;
+      final children =
+          element.children
+              ?.map((e) => e.toStringHuman(indent: indent + 2))
+              .join('\n') ??
+          '';
+      return '$indentString Element(tag: ${element.tag}, attributes: ${element.attributes}, children: [\n$children\n$indentString])';
+    } else if (this is md.Text) {
+      final text = this as md.Text;
+      return '$indentString Text(textContent: ${text.textContent})';
+    } else if (this is md.UnparsedContent) {
+      final unparsedContent = this as md.UnparsedContent;
+      return '$indent StringUnparsedContent(textContent: ${unparsedContent.textContent})';
+    }
+    return '$indentString Text(textContent: $textContent)';
+  }
+} */
+
+Widget buildText(BuildContext context, md.Element text) {
+  final theme = LdTheme.of(context);
+  return Text.rich(
+    TextSpan(
+      children: [
+        ...text.children?.map((e) => buildTextSpan(context, e)).toList() ?? [],
+      ],
+      style: switch (text.tag) {
+        'p' => ldBuildTextStyle(theme, LdTextType.paragraph, LdSize.m),
+        'h1' => ldBuildTextStyle(theme, LdTextType.headline, LdSize.l),
+        'h2' => ldBuildTextStyle(theme, LdTextType.headline, LdSize.m),
+        'h3' => ldBuildTextStyle(theme, LdTextType.headline, LdSize.s),
+        'h4' => ldBuildTextStyle(theme, LdTextType.headline, LdSize.xs),
+        'h5' => ldBuildTextStyle(theme, LdTextType.headline, LdSize.xs),
+        'h6' => ldBuildTextStyle(theme, LdTextType.headline, LdSize.xs),
+        _ => throw Exception('Invalid text type: ${text.tag}'),
+      },
+    ),
+  );
+}
+
+TextSpan buildTextSpan(BuildContext context, md.Node node) {
+  if (node is md.Text) {
+    return TextSpan(text: node.textContent);
+  } else if (node is md.Element) {
+    final theme = LdTheme.of(context);
+    final children =
+        node.children?.map((e) => buildTextSpan(context, e)).toList() ?? [];
+    return switch (node.tag) {
+      'strong' => TextSpan(
+        children: [...children],
+        style: TextStyle(fontWeight: FontWeight.bold),
+      ),
+      'em' || 'i' => TextSpan(
+        children: [...children],
+        style: TextStyle(fontStyle: FontStyle.italic),
+      ),
+      'a' => TextSpan(
+        children: [...children],
+        mouseCursor: SystemMouseCursors.click,
+        recognizer: TapGestureRecognizer()
+          ..onTap = () {
+            launchUrl(Uri.parse(node.attributes['href'] ?? ''));
+          },
+        style: TextStyle(color: theme.primaryColor),
+      ),
+      'code' => TextSpan(
+        children: [...children],
+        style: TextStyle(
+          fontFamily: 'monospace',
+          background: Paint()..color = theme.surface,
+        ),
+      ),
+      _ => TextSpan(children: children),
+    };
+  }
+  return TextSpan(text: node.textContent);
+}

--- a/packages/liquid_flutter_md/pubspec.yaml
+++ b/packages/liquid_flutter_md/pubspec.yaml
@@ -1,0 +1,23 @@
+name: liquid_flutter_md
+description: "Markdown rendering package for Liquid Flutter"
+version: 0.0.1
+
+environment:
+  sdk: ^3.10.7
+  flutter: ">=1.17.0"
+
+resolution: workspace
+dependencies:
+  flutter:
+    sdk: flutter
+  collection: ^1.19.1
+  liquid_flutter: any
+  html_unescape: ^2.0.0
+  markdown: ^7.3.0
+  syntax_highlight: ^0.5.0
+  url_launcher: ^6.3.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ workspace:
   - packages/liquid_generators
   - packages/liquid_flutter_test_utils
   - packages/liquid_flutter/extension/devtools/liquid_flutter_extension
+  - packages/liquid_flutter_md
   - apps/example
 dev_dependencies:
   melos: ^7.1.0
@@ -18,6 +19,7 @@ melos:
     testable:
       - packages/liquid_flutter
       - packages/liquid_flutter_test_utils
+      - packages/liquid_flutter_md
   scripts:
     test:
       exec: flutter test


### PR DESCRIPTION
Adds the liquid_flutter_md package for markdown rendering and wires it into the example app (route + drawer + demo screen).